### PR TITLE
PREVIEW Unify date formats

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,10 +7,10 @@
   "private": true,
   "ignore": [],
   "dependencies": {
-    "canjs": "2.0.7",
+    "canjs": "2.3.27",
     "bootstrap": "2.0.4",
-    "jquery-ui": "1.11.4",
-    "jquery": "1.11.3",
+    "jquery-ui": "1.12.1",
+    "jquery": "1.12.4",
     "lodash": "3.10.1",
     "mousetrap": "1.5.3",
     "moment": "2.15.0",

--- a/src/ggrc/assets/javascripts/components/add_comment/add_comment.js
+++ b/src/ggrc/assets/javascripts/components/add_comment/add_comment.js
@@ -42,7 +42,7 @@
           joins.splice(index, 1);
         });
       },
-      get_assignee_type: can.compute(function () {
+      get_assignee_type: function () {
         var types = new Map([
           ['related_verifiers', 'verifier'],
           ['related_assessors', 'assessor'],
@@ -71,7 +71,7 @@
           }
         });
         return user_type;
-      })
+      }
     },
     events: {
       inserted: function () {
@@ -112,7 +112,7 @@
           description: description,
           send_notification: this.scope.attr('sendNotification'),
           context: source.context,
-          assignee_type: this.scope.attr('get_assignee_type')
+          assignee_type: this.scope.get_assignee_type()
         };
 
         this.scope.attr('isSaving', true);

--- a/src/ggrc/assets/javascripts/components/csv/export.js
+++ b/src/ggrc/assets/javascripts/components/csv/export.js
@@ -18,12 +18,7 @@
         relevant: can.compute(function () {
           return new can.List();
         }),
-        columns: function () {
-          return _.filter(GGRC.model_attr_defs[this.attr("type")], function (el) {
-            return (!el.import_only) &&
-                   (el.display_name.indexOf("unmap:") === -1);
-          });
-        }
+        columns: [],
       }),
       panelsModel = can.Map({
         items: new can.List()
@@ -203,7 +198,15 @@
 
         this.scope.attr("_index", index);
         data.index = index;
-        return this.scope.attr("panels.items").push(new panelModel(data));
+        var pm = new panelModel(data);
+        pm.attr('columns', can.compute(function() {
+          var definitions = GGRC.model_attr_defs[pm.attr('type')];
+          return _.filter(definitions, function (el) {
+            return (!el.import_only) &&
+                   (el.display_name.indexOf("unmap:") === -1);
+          });
+        }));
+        return this.scope.attr("panels.items").push(pm);
       },
       getIndex: function (el) {
         return +el.closest("export-panel").control().scope.attr("item.index");

--- a/src/ggrc/assets/javascripts/components/csv/export.js
+++ b/src/ggrc/assets/javascripts/components/csv/export.js
@@ -30,10 +30,7 @@
         type: url.model_type || "Program",
         edit_filename: false,
         only_relevant: false,
-        filename: "Export Objects",
-        get_filename: function () {
-          return this.attr("filename").replace(/\s+/, "_").toLowerCase() + ".csv";
-        }
+        filename: "export_objects.csv"
       });
 
 
@@ -162,7 +159,7 @@
         GGRC.Utils.export_request({
           data: query
         }).then(function (data) {
-          GGRC.Utils.download(this.scope.attr("export.get_filename"), data);
+          GGRC.Utils.download(this.scope.attr("export.filename"), data);
         }.bind(this))
         .fail(function (data) {
           $("body").trigger("ajax:flash", {

--- a/src/ggrc/assets/javascripts/components/csv/export.js
+++ b/src/ggrc/assets/javascripts/components/csv/export.js
@@ -36,9 +36,9 @@
         edit_filename: false,
         only_relevant: false,
         filename: "Export Objects",
-        get_filename: can.compute(function () {
+        get_filename: function () {
           return this.attr("filename").replace(/\s+/, "_").toLowerCase() + ".csv";
-        })
+        }
       });
 
 

--- a/src/ggrc/assets/javascripts/components/csv/export.js
+++ b/src/ggrc/assets/javascripts/components/csv/export.js
@@ -188,7 +188,6 @@
         }
 
         this.scope.attr("_index", index);
-        data.index = index;
         var pm = new panelModel(data);
         pm.attr('columns', can.compute(function() {
           var definitions = GGRC.model_attr_defs[pm.attr('type')];

--- a/src/ggrc/assets/javascripts/components/csv/export.js
+++ b/src/ggrc/assets/javascripts/components/csv/export.js
@@ -28,7 +28,6 @@
         loading: false,
         url: "/_service/export_csv",
         type: url.model_type || "Program",
-        edit_filename: false,
         only_relevant: false,
         filename: "export_objects.csv"
       });
@@ -107,11 +106,6 @@
       };
     },
     events: {
-      ".btn-title-change click": function (el, ev) {
-        ev.preventDefault();
-        this.scope.attr("export.edit_filename", !this.scope.attr("export.edit_filename"));
-      },
-
       toggleIndicator: function (currentFilter) {
         var isExpression =
             !!currentFilter &&

--- a/src/ggrc/assets/javascripts/components/datepicker/datepicker.js
+++ b/src/ggrc/assets/javascripts/components/datepicker/datepicker.js
@@ -17,10 +17,9 @@
       format: '@',
       helptext: '@',
       isShown: false,
-      pattern: 'MM/DD/YYYY',
       setMinDate: null,
       setMaxDate: null,
-      _date: null,
+      _date: null,  // the internal value of the text input field
       required: '@',
       define: {
         label: {
@@ -32,7 +31,7 @@
         }
       },
       onSelect: function (val, ev) {
-        this.attr('_date', val);
+        this.attr('date', val);
         this.attr('isShown', false);
       },
       onFocus: function (el, ev) {
@@ -42,45 +41,96 @@
         if (!GGRC.Utils.inViewport(this.picker)) {
           this.attr('showTop', true);
         }
-      }
+      },
+
+      // Date formats for the actual selected value, and for the date as
+      // displayed to the user. The Moment.js library and the jQuery datepicker
+      // use different format notation, thus separate settings for each.
+      // IMPORTANT: The pair of settings for each "type" of value (i.e. actual
+      // value / display value) must be consistent across both libraries!
+      MOMENT_ISO_DATE: 'YYYY-MM-DD',
+      MOMENT_DISPLAY_FMT: 'MM/DD/YYYY',
+      PICKER_ISO_DATE: 'yy-mm-dd',
+      PICKER_DISPLAY_FMT: 'mm/dd/yy'
     },
+
     events: {
       inserted: function () {
+        var scope = this.scope;
         var element = this.element.find('.datepicker__calendar');
-        var date = this.getDate(this.scope.date);
+        var minDate;
+        var maxDate;
+        var date;
+        var dateObj = null;  // the current date value as an object
 
         element.datepicker({
+          dateFormat: scope.PICKER_ISO_DATE,
           altField: this.element.find('.datepicker__input'),
+          altFormat: scope.PICKER_DISPLAY_FMT,
           onSelect: this.scope.onSelect.bind(this.scope)
         });
+        scope.attr('picker', element);
 
-        this.scope.attr('picker', element);
+        date = this.getDate(scope.date);
+        if (date) {
+          dateObj = moment.utc(date).toDate();
+        }
+        scope.picker.datepicker('setDate', dateObj);
 
-        this.scope.picker.datepicker('setDate', date);
-        if (this.scope.setMinDate) {
-          this.updateDate('minDate', this.scope.setMinDate);
+        // set the boundaries of the dates that user is allowed to select
+        minDate = this.getDate(scope.setMinDate);
+        maxDate = this.getDate(scope.setMaxDate);
+        scope.attr('setMinDate', minDate);
+        scope.attr('setMaxDate', maxDate);
+
+        if (scope.setMinDate) {
+          this.updateDate('minDate', scope.setMinDate);
         }
-        if (this.scope.setMaxDate) {
-          this.updateDate('maxDate', this.scope.setMaxDate);
+        if (scope.setMaxDate) {
+          this.updateDate('maxDate', scope.setMaxDate);
         }
-        this.scope._date = date;
       },
+
+      /**
+       * Convert given date to an ISO date string.
+       *
+       * @param {Date|string|null} date - the date to convert
+       * @return {string|null} - date in ISO format or null if empty or invalid
+       */
       getDate: function (date) {
+        var scope = this.scope;
+
         if (date instanceof Date) {
-          return moment(date).format(this.scope.pattern);
-        }
-        if (moment(date, 'YYYY-MM-DD').isValid()) {
-          return moment(date).format(this.scope.pattern);
-        }
-        if (this.isValidDate(date)) {
+          // NOTE: Not using moment.utc(), because if a Date instance is given,
+          // it is in the browser's local timezone, thus we need to take that
+          // into account to not end up with a different date. Ideally this
+          // should never happen, but that would require refactoring the way
+          // Date objects are created throughout the app.
+          return moment(date).format(scope.MOMENT_ISO_DATE);
+        } else if (this.isValidDate(date)) {
           return date;
         }
         return null;
       },
+
       isValidDate: function (date) {
-        return moment(date, this.scope.pattern, true).isValid();
+        var scope = this.scope;
+        return moment(date, scope.MOMENT_ISO_DATE, true).isValid();
       },
+
+      /**
+       * Change the min/max date allowed to be picked.
+       *
+       * @param {string} type - the setting to change ("minDate" or "maxDate").
+       *   The value given is automatically adjusted for a day as business
+       *   rules dictate.
+       * @param {Date|string|null} date - the new value of the `type` setting.
+       *   If given as string, it must be in ISO date format.
+       * @return {Date|null} - the new date value
+       */
       updateDate: function (type, date) {
+        var scope = this.scope;
+
         var types = {
           minDate: function () {
             date.add(1, 'day');
@@ -89,32 +139,59 @@
             date.subtract(1, 'day');
           }
         };
+
         if (!date) {
-          this.scope.picker.datepicker('option', type, null);
-          return;
+          scope.picker.datepicker('option', type, null);
+          return null;
         }
-        date = moment(date, "MM/DD/YYYY");
+
+        if (date instanceof Date) {
+          // NOTE: Not using moment.utc(), because if a Date instance is given,
+          // it is in the browser's local timezone, thus we need to take that
+          // into account to not end up with a different date. Ideally this
+          // should never happen, but that would require refactoring the way
+          // Date objects are created throughout the app.
+          date = moment(date).format(scope.MOMENT_ISO_DATE);
+        }
+        date = moment.utc(date);
 
         if (types[type]) {
           types[type]();
         }
         date = date.toDate();
-        this.scope.picker.datepicker('option', type, date);
+        scope.picker.datepicker('option', type, date);
         return date;
       },
+
       '{scope} setMinDate': function (scope, ev, date) {
+        var currentDateObj = null;
         var updated = this.updateDate('minDate', date);
-        if (this.scope.attr('date') < updated) {
-          this.scope.attr('_date', moment(updated).format(this.scope.pattern));
+
+        if (scope.date) {
+          currentDateObj = moment.utc(scope.date).toDate();
+          if (currentDateObj < updated) {
+            this.scope.attr(
+              '_date',
+              moment.utc(updated).format(scope.MOMENT_DISPLAY_FMT));
+          }
         }
       },
+
       '{scope} setMaxDate': function (scope, ev, date) {
         this.updateDate('maxDate', date);
       },
+
       '{scope} _date': function (scope, ev, val) {
-        scope.attr('date', val);
-        scope.picker.datepicker('setDate', val);
+        var valISO = null;
+
+        if (val) {
+          valISO = moment.utc(val, scope.MOMENT_DISPLAY_FMT)
+                         .format(scope.MOMENT_ISO_DATE);
+        }
+        scope.attr('date', valISO);
+        scope.picker.datepicker('setDate', valISO);
       },
+
       '{window} mousedown': function (el, ev) {
         var isInside;
 

--- a/src/ggrc/assets/javascripts/components/datepicker/datepicker.js
+++ b/src/ggrc/assets/javascripts/components/datepicker/datepicker.js
@@ -67,11 +67,15 @@
       },
       getDate: function (date) {
         if (date instanceof Date) {
-          date = moment(date).format(this.scope.pattern);
-        } else if (!this.isValidDate(date)) {
-          date = null;
+          return moment(date).format(this.scope.pattern);
         }
-        return date;
+        if (moment(date, 'YYYY-MM-DD').isValid()) {
+          return moment(date).format(this.scope.pattern);
+        }
+        if (this.isValidDate(date)) {
+          return date;
+        }
+        return null;
       },
       isValidDate: function (date) {
         return moment(date, this.scope.pattern, true).isValid();
@@ -89,7 +93,7 @@
           this.scope.picker.datepicker('option', type, null);
           return;
         }
-        date = moment(date);
+        date = moment(date, "MM/DD/YYYY");
 
         if (types[type]) {
           types[type]();

--- a/src/ggrc/assets/javascripts/components/info-pin-buttons/info-pin-buttons.js
+++ b/src/ggrc/assets/javascripts/components/info-pin-buttons/info-pin-buttons.js
@@ -23,14 +23,16 @@
       },
       toggleSize: function (scope, el, ev) {
         var maximized = !this.attr('maximized');
+        var onChangeMaximizedState = Mustache.resolve(this.onChangeMaximizedState);
         ev.preventDefault();
         this.attr('maximized', maximized);
-        this.onChangeMaximizedState(maximized);
+        onChangeMaximizedState(maximized);
       },
       close: function (scope, el, ev) {
+        var onClose = Mustache.resolve(this.onClose);
         el.find('[rel=tooltip]').data('tooltip').hide();
         ev.preventDefault();
-        this.onClose();
+        onClose();
       }
     }
   });

--- a/src/ggrc/assets/javascripts/components/inline_edit/inline_datepicker.js
+++ b/src/ggrc/assets/javascripts/components/inline_edit/inline_datepicker.js
@@ -20,7 +20,7 @@
         if (_.isEmpty(val)) {
           return;
         }
-        if (!moment(val, 'MM/DD/YYYY', true).isValid()) {
+        if (!moment(val, 'YYYY-MM-DD', true).isValid()) {
           this.scope.attr('context.value', undefined);
         }
       }

--- a/src/ggrc/assets/javascripts/components/paginate.js
+++ b/src/ggrc/assets/javascripts/components/paginate.js
@@ -76,12 +76,12 @@
         *                     pageNum: `True page number that gets passed to setPage function`
         *                   }
         */
-      totalPages: can.compute(function () {
+      totalPages: function () {
         var list = this.attr('list');
         var perPage = Number(this.attr('perPage'));
 
         return Math.ceil(list.length / perPage);
-      })
+      }
     }
   });
 })(window.can, window.can.$);

--- a/src/ggrc/assets/javascripts/components/relevant_filters.js
+++ b/src/ggrc/assets/javascripts/components/relevant_filters.js
@@ -17,7 +17,7 @@
       relevant_menu_item: '@',
       show_all: '@',
       addFilter: function () {
-        var menu = this.attr('menu');
+        var menu = this.menu();
 
         if (this.attr('relevant_menu_item') === 'parent' &&
              Number(this.attr('panel_number')) !== 0 &&

--- a/src/ggrc/assets/javascripts/components/relevant_filters.js
+++ b/src/ggrc/assets/javascripts/components/relevant_filters.js
@@ -35,7 +35,7 @@
           model_name: menu[0].model_singular
         });
       },
-      menu: can.compute(function () {
+      menu: function () {
         var type = this.attr('type');
         var mappings;
         var models;
@@ -58,7 +58,7 @@
         return _.sortBy(_.compact(_.map(_.keys(mappings), function (mapping) {
           return CMS.Models[mapping];
         })), 'model_singular');
-      })
+      }
     },
     events: {
       init: function () {

--- a/src/ggrc/assets/javascripts/components/unified_mapper/mapper_checkbox.js
+++ b/src/ggrc/assets/javascripts/components/unified_mapper/mapper_checkbox.js
@@ -11,7 +11,7 @@
     template: '<content />',
     scope: {
       instance: null,
-      checkbox: can.compute(function (status) {
+      checkbox: function (status) {
         if (this.attr('mapper.getList') && !this.attr('appended')) {
           return false;
         }
@@ -20,7 +20,7 @@
           this.attr('select_state') ||
           this.attr('appended')
         );
-      }),
+      },
       define: {
         isMapped: {
           type: 'boolean',

--- a/src/ggrc/assets/javascripts/components/unified_mapper/mapper_results.js
+++ b/src/ggrc/assets/javascripts/components/unified_mapper/mapper_results.js
@@ -17,9 +17,9 @@
       page: 0,
       page_loading: false,
       select_state: false,
-      loading_or_saving: can.compute(function () {
+      loading_or_saving: function () {
         return this.attr('page_loading') || this.attr('mapper.is_saving');
-      }),
+      },
       isRelevantToCurrent: function () {
         var relevant = this.attr('mapper.relevant');
         var instance = GGRC.page_instance();

--- a/src/ggrc/assets/javascripts/controllers/dashboard_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/dashboard_controller.js
@@ -371,7 +371,7 @@
         dashboardCtr.show_widget_area();
         widget.siblings().addClass('hidden').trigger('widget_hidden');
         widget.removeClass('hidden').trigger('widget_shown');
-        $('[href$=' + panel + ']')
+        $('[href$="' + panel + '"]')
         .closest('li').addClass('active')
         .siblings().removeClass('active');
       }

--- a/src/ggrc/assets/javascripts/models/audit_models.js
+++ b/src/ggrc/assets/javascripts/models/audit_models.js
@@ -171,9 +171,9 @@
       );
     }
   }, {
-    object_model: can.compute(function () {
+    object_model: function () {
       return CMS.Models[this.attr('object_type')];
-    }),
+    },
     clone: function (options) {
       var model = CMS.Models.Audit;
       return new model({

--- a/src/ggrc/assets/javascripts/models/audit_models.js
+++ b/src/ggrc/assets/javascripts/models/audit_models.js
@@ -637,7 +637,7 @@
 
       // remove the groups that have ended up being empty
       objectTypes = _.pick(objectTypes, function (objGroup) {
-        return objGroup.items.length > 0;
+        return objGroup.items && objGroup.items.length > 0;
       });
 
       return objectTypes;

--- a/src/ggrc/assets/javascripts/models/cacheable.js
+++ b/src/ggrc/assets/javascripts/models/cacheable.js
@@ -1115,11 +1115,14 @@
     serialize: function () {
       var that = this;
       var serial = {};
+      var fnName;
+      var val;
+      var name;
       if (arguments.length) {
         return this._super.apply(this, arguments);
       }
-      this.each(function (val, name) {
-        var fnName;
+      for (name in this._data) {
+        val = this[name];
         if (that.constructor.attributes && that.constructor.attributes[name]) {
           fnName = that.constructor.attributes[name];
           fnName = fnName.substr(fnName.lastIndexOf('.') + 1);
@@ -1133,7 +1136,7 @@
           fnName === 'model' || fnName === 'get_instance') {
             serial[name] = (val ? val.stub().serialize() : null);
           } else {
-            serial[name] = that._super(name);
+            serial[name] = val;
           }
         } else if (val && typeof val.save === 'function') {
           serial[name] = val.stub().serialize();
@@ -1150,10 +1153,10 @@
           } else {
             serial[name] = that[name] && that[name].serialize ?
             that[name].serialize() :
-            that._super(name);
+            serial[name] = val;
           }
         }
-      });
+      }
       return serial;
     },
     display_name: function () {

--- a/src/ggrc/assets/javascripts/models/cacheable.js
+++ b/src/ggrc/assets/javascripts/models/cacheable.js
@@ -899,17 +899,17 @@
         this.custom_attributes.attr(attrId, 'Person:None');
       }
     },
-    computed_errors: can.compute(function () {
+    computed_errors: function () {
       var errors = this.errors();
       if (this.attr('_suppress_errors')) {
         return null;
       } else {
         return errors;
       }
-    }),
-    computed_unsuppressed_errors: can.compute(function () {
+    },
+    computed_unsuppressed_errors: function () {
       return this.errors();
-    }),
+    },
     get_list_counter: function (name) {
       var binding = this.get_binding(name);
       if (!binding) {

--- a/src/ggrc/assets/javascripts/models/issue.js
+++ b/src/ggrc/assets/javascripts/models/issue.js
@@ -36,8 +36,8 @@
       this.validateNonBlank('title');
     }
   }, {
-    object_model: can.compute(function () {
+    object_model: function () {
       return CMS.Models[this.attr('object_type')];
-    })
+    }
   });
 })(this.can);

--- a/src/ggrc/assets/javascripts/models/mixins.js
+++ b/src/ggrc/assets/javascripts/models/mixins.js
@@ -324,10 +324,31 @@
     }
   });
 
+  /**
+   * A mixin to use for objects that can have a time limit imposed on them.
+   *
+   * @class CMS.Models.Mixins.timeboxed
+   */
   can.Model.Mixin('timeboxed', {
     'extend:attributes': {
       start_date: 'date',
       end_date: 'date'
+    },
+
+    // Override default CanJS's conversion/serialization of dates, because
+    // that takes the browser's local timezone into account, which we do not
+    // want with our UTC dates. Having plain UTC-formatted date strings is
+    // more suitable for the current structure of the app.
+    serialize: {
+      date: function (val, type) {
+        return val;
+      }
+    },
+
+    convert: {
+      date: function (val, oldVal, fn, type) {
+        return val;
+      }
     }
   }, {
   });

--- a/src/ggrc/assets/javascripts/models/mixins.js
+++ b/src/ggrc/assets/javascripts/models/mixins.js
@@ -51,6 +51,7 @@
             key.substr(0, key.indexOf(':')) :
             'after';
           var oldfn;
+          var key;
 
           key = ~key.indexOf(':') ? key.substr(key.indexOf(':') + 1) : key;
           if (fn !== can.Model.Mixin[key] && !~can.inArray(key, blockedKeys)) {
@@ -92,8 +93,11 @@
       if (!~can.inArray(this.fullName, cls._mixins)) {
         cls._mixins = cls._mixins || [];
         cls._mixins.push(this.fullName);
-
-        can.each(this, setupfns(cls));
+        for (key in this) {
+          if (this.hasOwnProperty(key)) {
+            setupfns(cls).call(null, this[key], key);
+          }
+        }
         can.each(this.prototype, setupfns(cls.prototype));
       }
     }

--- a/src/ggrc/assets/javascripts/mustache_helper.js
+++ b/src/ggrc/assets/javascripts/mustache_helper.js
@@ -1493,11 +1493,13 @@ Mustache.registerHelper("json_escape", function (obj, options) {
 
 function localizeDate(date, options, tmpl) {
   if (!options) {
-    date = new Date();
-  } else {
-    date = resolve_computed(date);
+    return moment().format(tmpl);
   }
-  return date ? moment(date).format(tmpl) : '';
+  date = resolve_computed(date);
+  if (date) {
+    return moment(new Date(date)).format(tmpl);
+  }
+  return '';
 }
 
 can.each({

--- a/src/ggrc/assets/js_specs/models/display_prefs_spec.js
+++ b/src/ggrc/assets/js_specs/models/display_prefs_spec.js
@@ -5,7 +5,7 @@
 
 
 describe("display prefs model", function() {
-  
+
   var display_prefs, exp;
   beforeAll(function() {
     display_prefs = new CMS.Models.DisplayPrefs();
@@ -28,7 +28,7 @@ describe("display prefs model", function() {
     beforeEach(function() {
       display_prefs.attr("foo", "bar");
     });
-    
+
     afterEach(function() {
       display_prefs.removeAttr("foo");
       display_prefs.removeAttr("baz");
@@ -76,22 +76,21 @@ describe("display prefs model", function() {
     describe("hiddenness", function () {
       it("sets nav hidden", function() {
         display_prefs.setTopNavHidden("this arg is ignored", true);
-            
         expect(
           display_prefs.attr(exp.path).top_nav.is_hidden
         ).toBe(true);
       });
-        
+
       it("gets nav hidden", function () {
         display_prefs.setTopNavHidden("this arg is ignored", true);
-            
+
         expect(display_prefs.getTopNavHidden()).toBe(true);
       });
-        
+
       it("returns false by default", function () {
         expect(display_prefs.getTopNavHidden()).toBe(false);
       });
-    }); 
+    });
 
     describe("widget list", function () {
       it("sets widget list", function () {
@@ -101,7 +100,7 @@ describe("display prefs model", function() {
           display_prefs.attr(exp.path).top_nav.widget_list.serialize()
         ).toEqual({a: 1, b: 2});
       });
-        
+
       it("gets widget list", function () {
         display_prefs.setTopNavWidgets("this arg is ignored", {a: 1, b: 2});
 
@@ -116,26 +115,26 @@ describe("display prefs model", function() {
 
    describe("filter hiding", function () {
      afterEach(function() {
-       display_prefs.resetPagePrefs(); 
+       display_prefs.resetPagePrefs();
      });
 
      it("sets filter hidden", function() {
        display_prefs.setFilterHidden(true);
-         
+
        expect(
          display_prefs.attr(exp.path).filter_widget.is_hidden
        ).toBe(true);
      });
-        
+
      it("gets filter hidden", function () {
        display_prefs.setFilterHidden(true);
-            
+
        expect(display_prefs.getFilterHidden()).toBe(true);
      });
-        
+
      it("returns false by default", function () {
        expect(display_prefs.getFilterHidden()).toBe(false);
-     }); 
+     });
    });
 
 
@@ -160,7 +159,7 @@ describe("display prefs model", function() {
       function getTest() {
         var fooActual = display_prefs[func]("unit_test", "foo");
         var barActual = display_prefs[func]("unit_test", "bar");
-       
+
         expect(fooActual.serialize ? fooActual.serialize() : fooActual)[fooMatcher](fooValue);
         expect(barActual.serialize ? barActual.serialize() : barActual)[barMatcher](barValue);
       }
@@ -220,7 +219,7 @@ describe("display prefs model", function() {
         display_prefs.removeAttr(exp.path);
       });
 
-      
+
       it("sets the value for a widget", function() {
         display_prefs[func]("this arg is ignored", "foo", fooValue);
         var fooActual  = display_prefs.attr([exp.path, exp_token, "foo"].join("."));
@@ -339,7 +338,7 @@ describe("display prefs model", function() {
         expect(dps).not.toContain(dp_noversion);
         expect(dp_noversion.destroy).toHaveBeenCalled();
       });
-        
+
       waitsFor(function() { //sanity check --ensure deferred resolves/rejects
         return dfd.state() !== "pending";
       }, done);

--- a/src/ggrc/assets/js_specs/models/display_prefs_spec.js
+++ b/src/ggrc/assets/js_specs/models/display_prefs_spec.js
@@ -78,7 +78,7 @@ describe("display prefs model", function() {
         display_prefs.setTopNavHidden("this arg is ignored", true);
             
         expect(
-          display_prefs.attr([exp.path, exp.TOP_NAV].join(".")).top_nav.is_hidden
+          display_prefs.attr(exp.path).top_nav.is_hidden
         ).toBe(true);
       });
         
@@ -98,7 +98,7 @@ describe("display prefs model", function() {
         display_prefs.setTopNavWidgets("this arg is ignored", {a:1, b: 2});
 
         expect(
-          display_prefs.attr([exp.path, exp.TOP_NAV].join(".")).top_nav.widget_list.serialize()
+          display_prefs.attr(exp.path).top_nav.widget_list.serialize()
         ).toEqual({a: 1, b: 2});
       });
         
@@ -123,7 +123,7 @@ describe("display prefs model", function() {
        display_prefs.setFilterHidden(true);
          
        expect(
-         display_prefs.attr([exp.path, exp.FILTER_WIDGET].join(".")).filter_widget.is_hidden
+         display_prefs.attr(exp.path).filter_widget.is_hidden
        ).toBe(true);
      });
         

--- a/src/ggrc/assets/mockups/mockup_base_templates/info_panel/issues_list.mustache
+++ b/src/ggrc/assets/mockups/mockup_base_templates/info_panel/issues_list.mustache
@@ -40,7 +40,7 @@
                     </div>
                   </div>
 
-                  {{{render '/static/mustache/base_objects/contacts.mustache' instance=instance}}}
+                  {{>'/static/mustache/base_objects/contacts.mustache'}}
 
                 </div>
               </div>

--- a/src/ggrc/assets/mockups/mockup_base_templates/info_panel/past_items_list.mustache
+++ b/src/ggrc/assets/mockups/mockup_base_templates/info_panel/past_items_list.mustache
@@ -65,7 +65,7 @@
                             </div>
                           </div>
 
-                          {{{render '/static/mustache/base_objects/contacts.mustache' instance=instance}}}
+                          {{>'/static/mustache/base_objects/contacts.mustache'}}
 
                         </div>
                       </div>

--- a/src/ggrc/assets/mockups/mockup_base_templates/info_panel/requests_list.mustache
+++ b/src/ggrc/assets/mockups/mockup_base_templates/info_panel/requests_list.mustache
@@ -40,7 +40,7 @@
                     </div>
                   </div>
 
-                  {{{render '/static/mustache/base_objects/contacts.mustache' instance=instance}}}
+                  {{>'/static/mustache/base_objects/contacts.mustache'}}
 
                 </div>
               </div>

--- a/src/ggrc/assets/mockups/quick-workflow/info.mustache
+++ b/src/ggrc/assets/mockups/quick-workflow/info.mustache
@@ -128,7 +128,7 @@
 
     </div><!-- tier-content end -->
 
-  {{{render '/static/mustache/custom_attributes/info.mustache' instance=instance}}}
+  {{>'/static/mustache/custom_attributes/info.mustache'}}
 
   </section>
 
@@ -138,7 +138,7 @@
         <em>
           Created at 10/09/2015
           &nbsp;&nbsp;&nbsp;&nbsp;
-          Modified by {{#using person=modified_by}}{{{render '/static/mustache/people/popover.mustache' person=person}}}{{/using}} on 11/30/2016
+          Modified by {{#using person=modified_by}}{{>'/static/mustache/people/popover.mustache'}}{{/using}} on 11/30/2016
         </em>
       </small>
     </p>

--- a/src/ggrc/assets/mockups/request/info.mustache
+++ b/src/ggrc/assets/mockups/request/info.mustache
@@ -212,7 +212,7 @@
 
     </div><!-- tier-content end -->
 
-  {{{render '/static/mustache/custom_attributes/info.mustache' instance=instance}}}
+  {{>'/static/mustache/custom_attributes/info.mustache'}}
 
   </section>
 
@@ -222,7 +222,7 @@
         <em>
           Created at 10/09/2015
           &nbsp;&nbsp;&nbsp;&nbsp;
-          Modified by {{#using person=modified_by}}{{{render '/static/mustache/people/popover.mustache' person=person}}}{{/using}} on 11/30/2016
+          Modified by {{#using person=modified_by}}{{>'/static/mustache/people/popover.mustache'}}{{/using}} on 11/30/2016
         </em>
       </small>
     </p>

--- a/src/ggrc/assets/mockups/workflow/info.mustache
+++ b/src/ggrc/assets/mockups/workflow/info.mustache
@@ -120,7 +120,7 @@
         <em>
           Created at 10/09/2015
           &nbsp;&nbsp;&nbsp;&nbsp;
-          Modified by {{#using person=modified_by}}{{{render '/static/mustache/people/popover.mustache' person=person}}}{{/using}} on 11/30/2016
+          Modified by {{#using person=modified_by}}{{>'/static/mustache/people/popover.mustache'}}{{/using}} on 11/30/2016
         </em>
       </small>
     </p>

--- a/src/ggrc/assets/mustache/assessment_templates/info.mustache
+++ b/src/ggrc/assets/mustache/assessment_templates/info.mustache
@@ -7,7 +7,7 @@
   <section class="info{{#is_info_pin}} sticky-info-panel{{/is_info_pin}}">
 
     {{#is_info_pin}}
-      <info-pin-buttons class="details-wrap" maximized="maximized" on-change-maximized-state="onChangeMaximizedState" on-close="onClose"></info-pin-buttons>
+      <info-pin-buttons class="details-wrap" maximized="maximized" on-change-maximized-state="@onChangeMaximizedState" on-close="@onClose"></info-pin-buttons>
     {{/is_info_pin}}
 
     {{> /static/mustache/base_objects/info-pane-utility.mustache}}

--- a/src/ggrc/assets/mustache/assessment_templates/info.mustache
+++ b/src/ggrc/assets/mustache/assessment_templates/info.mustache
@@ -114,7 +114,7 @@
         <em>
           Created at {{date created_at}}
           &nbsp;&nbsp;&nbsp;&nbsp;
-          Modified by {{#using person=modified_by}}{{{render '/static/mustache/people/popover.mustache' person=person}}}{{/using}} on {{date updated_at}}
+          Modified by {{#using person=modified_by}}{{>'/static/mustache/people/popover.mustache'}}{{/using}} on {{date updated_at}}
         </em>
       </small>
     </p>

--- a/src/ggrc/assets/mustache/assessment_templates/tier2_content.mustache
+++ b/src/ggrc/assets/mustache/assessment_templates/tier2_content.mustache
@@ -6,8 +6,8 @@
 {{> /static/mustache/base_objects/dropdown_menu_tier2.mustache}}
 
 <div class="tier-content">
-  {{{render '/static/mustache/base_objects/general_info.mustache' instance=instance }}}
-  {{{render '/static/mustache/base_objects/mappings_detail.mustache' result=result parent_instance=parent_instance}}}
-  {{{render '/static/mustache/base_objects/urls.mustache' instance=instance}}}
-  {{{render '/static/mustache/base_objects/notes_and_code.mustache' instance=instance}}}
+  {{>'/static/mustache/base_objects/general_info.mustache'}}
+  {{>'/static/mustache/base_objects/mappings_detail.mustache'}}
+  {{>'/static/mustache/base_objects/urls.mustache'}}
+  {{>'/static/mustache/base_objects/notes_and_code.mustache'}}
 </div>

--- a/src/ggrc/assets/mustache/assessments/info.mustache
+++ b/src/ggrc/assets/mustache/assessments/info.mustache
@@ -6,7 +6,7 @@
 {{#instance}}
     <section class="assessment-module info{{#is_info_pin}} sticky-info-panel assignable{{/is_info_pin}}">
       {{#is_info_pin}}
-          <info-pin-buttons class="details-wrap" maximized="maximized" on-change-maximized-state="onChangeMaximizedState" on-close="onClose"></info-pin-buttons>
+          <info-pin-buttons class="details-wrap" maximized="maximized" on-change-maximized-state="@onChangeMaximizedState" on-close="@onClose"></info-pin-buttons>
       {{/is_info_pin}}
 
         <div class="tier-content">

--- a/src/ggrc/assets/mustache/audits/info.mustache
+++ b/src/ggrc/assets/mustache/audits/info.mustache
@@ -7,7 +7,7 @@
   <section class="info{{#is_info_pin}} sticky-info-panel{{/is_info_pin}}">
 
     {{#is_info_pin}}
-      <info-pin-buttons class="details-wrap" maximized="maximized" on-change-maximized-state="onChangeMaximizedState" on-close="onClose"></info-pin-buttons>
+      <info-pin-buttons class="details-wrap" maximized="maximized" on-change-maximized-state="@onChangeMaximizedState" on-close="@onClose"></info-pin-buttons>
     {{/is_info_pin}}
 
     {{> /static/mustache/base_objects/info-pane-utility.mustache}}

--- a/src/ggrc/assets/mustache/audits/info.mustache
+++ b/src/ggrc/assets/mustache/audits/info.mustache
@@ -152,7 +152,7 @@
         {{{render_hooks 'Audit.tree_view_info'}}}
       </div>
     </div>
-    {{{render '/static/mustache/custom_attributes/info.mustache' instance=instance}}}
+    {{>'/static/mustache/custom_attributes/info.mustache'}}
   </section>
 
   <div class="info-widget-footer">
@@ -161,7 +161,7 @@
         <em>
           Created at {{date created_at}}
           &nbsp;&nbsp;&nbsp;&nbsp;
-          Modified by {{#using person=modified_by}}{{{render '/static/mustache/people/popover.mustache' person=person}}}{{/using}} on {{date updated_at}}
+          Modified by {{#using person=modified_by}}{{>'/static/mustache/people/popover.mustache'}}{{/using}} on {{date updated_at}}
         </em>
       </small>
     </p>

--- a/src/ggrc/assets/mustache/base_objects/extended_info.mustache
+++ b/src/ggrc/assets/mustache/base_objects/extended_info.mustache
@@ -55,7 +55,7 @@
   {{/if_equals}}
 
   {{^if_equals instance.class.table_singular 'person'}}
-    {{{render '/static/mustache/base_objects/contacts.mustache' instance=instance}}}
+    {{>'/static/mustache/base_objects/contacts.mustache'}}
   {{/if_equals}}
 
   <div class="row-fluid">

--- a/src/ggrc/assets/mustache/base_objects/info.mustache
+++ b/src/ggrc/assets/mustache/base_objects/info.mustache
@@ -13,11 +13,11 @@
     {{> /static/mustache/base_objects/info-pane-utility.mustache}}
 
     <div class="tier-content">
-      {{{render '/static/mustache/base_objects/general_info.mustache' instance=instance}}}
-      {{{render '/static/mustache/base_objects/description.mustache' instance=instance}}}
-      {{{render '/static/mustache/base_objects/notes.mustache' instance=instance}}}
-      {{{render '/static/mustache/base_objects/contacts.mustache' instance=instance}}}
-      {{{render '/static/mustache/base_objects/urls.mustache' instance=instance}}}
+      {{>'/static/mustache/base_objects/general_info.mustache'}}
+      {{>'/static/mustache/base_objects/description.mustache'}}
+      {{>'/static/mustache/base_objects/notes.mustache'}}
+      {{>'/static/mustache/base_objects/contacts.mustache'}}
+      {{>'/static/mustache/base_objects/urls.mustache'}}
 
       <div class="custom-attr-wrap">
         <div class="row-fluid">
@@ -70,7 +70,7 @@
       </div><!-- custom-attr-wrap end -->
     </div><!-- tier-content end -->
 
-  {{{render '/static/mustache/custom_attributes/info.mustache' instance=instance}}}
+  {{>'/static/mustache/custom_attributes/info.mustache'}}
 
   </section>
 
@@ -80,7 +80,7 @@
         <em>
           Created at {{date created_at}}
           &nbsp;&nbsp;&nbsp;&nbsp;
-          Modified by {{#using person=modified_by}}{{{render '/static/mustache/people/popover.mustache' person=person}}}{{/using}} on {{date updated_at}}
+          Modified by {{#using person=modified_by}}{{>'/static/mustache/people/popover.mustache'}}{{/using}} on {{date updated_at}}
         </em>
       </small>
     </p>

--- a/src/ggrc/assets/mustache/base_objects/info.mustache
+++ b/src/ggrc/assets/mustache/base_objects/info.mustache
@@ -7,7 +7,7 @@
   <section class="info{{#is_info_pin}} sticky-info-panel{{/is_info_pin}}">
 
     {{#is_info_pin}}
-      <info-pin-buttons class="details-wrap" maximized="maximized" on-change-maximized-state="onChangeMaximizedState" on-close="onClose"></info-pin-buttons>
+      <info-pin-buttons class="details-wrap" maximized="maximized" on-change-maximized-state="@onChangeMaximizedState" on-close="@onClose"></info-pin-buttons>
     {{/is_info_pin}}
 
     {{> /static/mustache/base_objects/info-pane-utility.mustache}}

--- a/src/ggrc/assets/mustache/base_templates/comment_subtree.mustache
+++ b/src/ggrc/assets/mustache/base_templates/comment_subtree.mustache
@@ -8,7 +8,7 @@
   <div class="w-status">
     <span class="entry-author">
       {{#using person=modified_by}}
-        {{{render '/static/mustache/people/popover.mustache' person=person}}}
+        {{>'/static/mustache/people/popover.mustache'}}
       {{/using}}
       {{assignee_types assignee_type}} added a response - {{date created_at}}
     </span>

--- a/src/ggrc/assets/mustache/components/assessment/inline/date.mustache
+++ b/src/ggrc/assets/mustache/components/assessment/inline/date.mustache
@@ -7,6 +7,10 @@
   <datepicker persistent="true" date="context.value"></datepicker>
 {{else}}
   <div class="inline-edit__text">
-    {{{firstnonempty context.value '<span class="empty-message">None</span>'}}}
+    {{#if context.value}}
+      {{date context.value true}}
+    {{else}}
+      <span class="empty-message">None</span>
+    {{/if}}
   </div>
 {{/if}}

--- a/src/ggrc/assets/mustache/components/datepicker/datepicker.mustache
+++ b/src/ggrc/assets/mustache/components/datepicker/datepicker.mustache
@@ -17,7 +17,7 @@
   <div class="datepicker__input-wrapper">
     <i class="fa fa-calendar"></i>
     <input
-      placeholder="{{pattern}}"
+      placeholder="{{displayFormat}}"
       type="text"
       class="datepicker__input date"
       can-value="_date"

--- a/src/ggrc/assets/mustache/components/info-pin-buttons/info-pin-buttons.mustache
+++ b/src/ggrc/assets/mustache/components/info-pin-buttons/info-pin-buttons.mustache
@@ -2,6 +2,7 @@
     Copyright (C) 2016 Google Inc.
     Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 }}
+
 <ul class="pin-action">
   {{#if maximized}}
   <li>

--- a/src/ggrc/assets/mustache/components/inline_edit/datepicker.mustache
+++ b/src/ggrc/assets/mustache/components/inline_edit/datepicker.mustache
@@ -7,6 +7,10 @@
   <datepicker persistent="true" date="context.value"></datepicker>
 {{else}}
   <p class="inline-edit__text">
-    {{{firstnonempty context.value '<span class="empty-message">None</span>'}}}
+    {{#if context.value}}
+      {{date context.value true}}
+    {{else}}
+      <span class="empty-message">None</span>
+    {{/if}}
   </p>
 {{/if}}

--- a/src/ggrc/assets/mustache/controls/info.mustache
+++ b/src/ggrc/assets/mustache/controls/info.mustache
@@ -7,7 +7,7 @@
   <section class="info{{#is_info_pin}} sticky-info-panel{{/is_info_pin}}">
 
     {{#is_info_pin}}
-      <info-pin-buttons class="details-wrap" maximized="maximized" on-change-maximized-state="onChangeMaximizedState" on-close="onClose"></info-pin-buttons>
+      <info-pin-buttons class="details-wrap" maximized="maximized" on-change-maximized-state="@onChangeMaximizedState" on-close="@onClose"></info-pin-buttons>
     {{/is_info_pin}}
 
     {{> /static/mustache/base_objects/info-pane-utility.mustache}}

--- a/src/ggrc/assets/mustache/controls/info.mustache
+++ b/src/ggrc/assets/mustache/controls/info.mustache
@@ -13,12 +13,12 @@
     {{> /static/mustache/base_objects/info-pane-utility.mustache}}
 
     <div class="tier-content">
-      {{{render '/static/mustache/base_objects/general_info.mustache' instance=instance}}}
-      {{{render '/static/mustache/base_objects/description.mustache' instance=instance}}}
-      {{{render '/static/mustache/base_objects/test_plan.mustache' instance=instance}}}
-      {{{render '/static/mustache/base_objects/notes.mustache' instance=instance}}}
-      {{{render '/static/mustache/base_objects/contacts.mustache' instance=instance}}}
-      {{{render '/static/mustache/base_objects/urls.mustache' instance=instance}}}
+      {{>'/static/mustache/base_objects/general_info.mustache'}}
+      {{>'/static/mustache/base_objects/description.mustache'}}
+      {{>'/static/mustache/base_objects/test_plan.mustache'}}
+      {{>'/static/mustache/base_objects/notes.mustache'}}
+      {{>'/static/mustache/base_objects/contacts.mustache'}}
+      {{>'/static/mustache/base_objects/urls.mustache'}}
 
       <div class="custom-attr-wrap">
         <div class="row-fluid">
@@ -197,7 +197,7 @@
       </div><!-- custom-attr-wrap end -->
     </div><!-- tier-content end -->
 
-  {{{render '/static/mustache/custom_attributes/info.mustache' instance=instance}}}
+  {{>'/static/mustache/custom_attributes/info.mustache'}}
 
   </section>
 
@@ -207,7 +207,7 @@
         <em>
           Created at {{date created_at}}
           &nbsp;&nbsp;&nbsp;&nbsp;
-          Modified by {{#using person=modified_by}}{{{render '/static/mustache/people/popover.mustache' person=person}}}{{/using}} on {{date updated_at}}
+          Modified by {{#using person=modified_by}}{{>'/static/mustache/people/popover.mustache'}}{{/using}} on {{date updated_at}}
         </em>
       </small>
     </p>

--- a/src/ggrc/assets/mustache/controls/tier2_content.mustache
+++ b/src/ggrc/assets/mustache/controls/tier2_content.mustache
@@ -6,8 +6,8 @@
 {{> /static/mustache/base_objects/dropdown_menu_tier2.mustache}}
 
 <div class="tier-content">
-  {{{render '/static/mustache/base_objects/general_info.mustache' instance=instance }}}
-  {{{render '/static/mustache/base_objects/description.mustache' instance=instance}}}
+  {{>'/static/mustache/base_objects/general_info.mustache'}}
+  {{>'/static/mustache/base_objects/description.mustache'}}
   {{{renderLive '/static/mustache/base_objects/notes_and_code.mustache' instance=instance}}}
   {{{renderLive '/static/mustache/base_objects/mappings_detail.mustache' result=result parent_instance=parent_instance}}}
   {{{renderLive '/static/mustache/base_objects/contacts.mustache' instance=instance}}}

--- a/src/ggrc/assets/mustache/directives/tier2_content.mustache
+++ b/src/ggrc/assets/mustache/directives/tier2_content.mustache
@@ -6,8 +6,8 @@
 {{> /static/mustache/base_objects/dropdown_menu_tier2.mustache}}
 
 <div class="tier-content">
-  {{{render '/static/mustache/base_objects/general_info.mustache' instance=instance }}}
-  {{{render '/static/mustache/base_objects/description.mustache' instance=instance}}}
+  {{>'/static/mustache/base_objects/general_info.mustache'}}
+  {{>'/static/mustache/base_objects/description.mustache'}}
   {{{renderLive '/static/mustache/base_objects/mappings_detail.mustache' result=result parent_instance=parent_instance}}}
   {{{renderLive '/static/mustache/base_objects/contacts.mustache' instance=instance}}}
   {{#instance.url}}

--- a/src/ggrc/assets/mustache/import_export/export.mustache
+++ b/src/ggrc/assets/mustache/import_export/export.mustache
@@ -9,16 +9,9 @@
     <div class="row-fluid">
       <div class="span12">
         <div class="report-title">
-          {{#if export.edit_filename}}
-            <div class="report-title-change">
-              <input type="text" can-value="export.filename" class="input-medium" placeholder="Enter report name">
-              <a class="btn btn-primary btn-title-change btn-small title-change" href="#">Save</a>
-            </div>
-          {{else}}
-            <h2 class="title">
-              Export Objects
-            </h2>
-          {{/if}}
+          <h2 class="title">
+            Export Objects
+          </h2>
         </div>
       </div>
     </div>

--- a/src/ggrc/assets/mustache/issues/info.mustache
+++ b/src/ggrc/assets/mustache/issues/info.mustache
@@ -13,12 +13,12 @@
     {{> /static/mustache/base_objects/info-pane-utility.mustache}}
 
     <div class="tier-content">
-      {{{render '/static/mustache/base_objects/general_info.mustache' instance=instance}}}
-      {{{render '/static/mustache/base_objects/description.mustache' instance=instance}}}
-      {{{render '/static/mustache/issues/remediation_plan.mustache' instance=instance}}}
-      {{{render '/static/mustache/base_objects/notes.mustache' instance=instance}}}
-      {{{render '/static/mustache/base_objects/contacts.mustache' instance=instance}}}
-      {{{render '/static/mustache/base_objects/urls.mustache' instance=instance}}}
+      {{>'/static/mustache/base_objects/general_info.mustache'}}
+      {{>'/static/mustache/base_objects/description.mustache'}}
+      {{>'/static/mustache/issues/remediation_plan.mustache'}}
+      {{>'/static/mustache/base_objects/notes.mustache'}}
+      {{>'/static/mustache/base_objects/contacts.mustache'}}
+      {{>'/static/mustache/base_objects/urls.mustache'}}
 
       <div class="custom-attr-wrap">
         <div class="row-fluid">
@@ -71,7 +71,7 @@
       </div><!-- custom-attr-wrap end -->
     </div><!-- tier-content end -->
 
-  {{{render '/static/mustache/custom_attributes/info.mustache' instance=instance}}}
+  {{>'/static/mustache/custom_attributes/info.mustache'}}
 
   </section>
 
@@ -81,7 +81,7 @@
         <em>
           Created at {{date created_at}}
           &nbsp;&nbsp;&nbsp;&nbsp;
-          Modified by {{#using person=modified_by}}{{{render '/static/mustache/people/popover.mustache' person=person}}}{{/using}} on {{date updated_at}}
+          Modified by {{#using person=modified_by}}{{>'/static/mustache/people/popover.mustache'}}{{/using}} on {{date updated_at}}
         </em>
       </small>
     </p>

--- a/src/ggrc/assets/mustache/issues/info.mustache
+++ b/src/ggrc/assets/mustache/issues/info.mustache
@@ -7,7 +7,7 @@
   <section class="info{{#is_info_pin}} sticky-info-panel{{/is_info_pin}}">
 
     {{#is_info_pin}}
-      <info-pin-buttons class="details-wrap" maximized="maximized" on-change-maximized-state="onChangeMaximizedState" on-close="onClose"></info-pin-buttons>
+      <info-pin-buttons class="details-wrap" maximized="maximized" on-change-maximized-state="@onChangeMaximizedState" on-close="@onClose"></info-pin-buttons>
     {{/is_info_pin}}
 
     {{> /static/mustache/base_objects/info-pane-utility.mustache}}

--- a/src/ggrc/assets/mustache/objectives/info.mustache
+++ b/src/ggrc/assets/mustache/objectives/info.mustache
@@ -13,11 +13,11 @@
     {{> /static/mustache/base_objects/info-pane-utility.mustache}}
 
     <div class="tier-content">
-      {{{render '/static/mustache/base_objects/general_info.mustache' instance=instance}}}
-      {{{render '/static/mustache/base_objects/description.mustache' instance=instance}}}
-      {{{render '/static/mustache/base_objects/notes.mustache' instance=instance}}}
-      {{{render '/static/mustache/base_objects/contacts.mustache' instance=instance}}}
-      {{{render '/static/mustache/base_objects/urls.mustache' instance=instance}}}
+      {{>'/static/mustache/base_objects/general_info.mustache'}}
+      {{>'/static/mustache/base_objects/description.mustache'}}
+      {{>'/static/mustache/base_objects/notes.mustache'}}
+      {{>'/static/mustache/base_objects/contacts.mustache'}}
+      {{>'/static/mustache/base_objects/urls.mustache'}}
 
       <div class="row-fluid wrap-row">
         <div class="span6">
@@ -29,7 +29,7 @@
       </div>
     </div><!-- tier-content end -->
 
-  {{{render '/static/mustache/custom_attributes/info.mustache' instance=instance}}}
+  {{>'/static/mustache/custom_attributes/info.mustache'}}
 
   </section>
 
@@ -39,7 +39,7 @@
         <em>
           Created at {{date created_at}}
           &nbsp;&nbsp;&nbsp;&nbsp;
-          Modified by {{#using person=modified_by}}{{{render '/static/mustache/people/popover.mustache' person=person}}}{{/using}} on {{date updated_at}}
+          Modified by {{#using person=modified_by}}{{>'/static/mustache/people/popover.mustache'}}{{/using}} on {{date updated_at}}
         </em>
       </small>
     </p>

--- a/src/ggrc/assets/mustache/objectives/info.mustache
+++ b/src/ggrc/assets/mustache/objectives/info.mustache
@@ -7,7 +7,7 @@
   <section class="info{{#is_info_pin}} sticky-info-panel{{/is_info_pin}}">
 
     {{#is_info_pin}}
-      <info-pin-buttons class="details-wrap" maximized="maximized" on-change-maximized-state="onChangeMaximizedState" on-close="onClose"></info-pin-buttons>
+      <info-pin-buttons class="details-wrap" maximized="maximized" on-change-maximized-state="@onChangeMaximizedState" on-close="@onClose"></info-pin-buttons>
     {{/is_info_pin}}
 
     {{> /static/mustache/base_objects/info-pane-utility.mustache}}

--- a/src/ggrc/assets/mustache/objectives/tier2_content.mustache
+++ b/src/ggrc/assets/mustache/objectives/tier2_content.mustache
@@ -6,8 +6,8 @@
 {{> /static/mustache/base_objects/dropdown_menu_tier2.mustache}}
 
 <div class="tier-content">
-  {{{render '/static/mustache/base_objects/general_info.mustache' instance=instance }}}
-  {{{render '/static/mustache/base_objects/description.mustache' instance=instance}}}
+  {{>'/static/mustache/base_objects/general_info.mustache'}}
+  {{>'/static/mustache/base_objects/description.mustache'}}
   {{{renderLive '/static/mustache/base_objects/notes_and_code.mustache' instance=instance}}}
   {{{renderLive '/static/mustache/base_objects/mappings_detail.mustache' result=result parent_instance=parent_instance}}}
   {{{renderLive '/static/mustache/base_objects/contacts.mustache' instance=instance}}}

--- a/src/ggrc/assets/mustache/people/active_column.mustache
+++ b/src/ggrc/assets/mustache/people/active_column.mustache
@@ -13,7 +13,7 @@
     <li class="{{#if _removed}}removed{{/if}}">
       <a class="jump-to-control" href="javascript://">
         <span>
-          {{{render '/static/mustache/people/popover.mustache' person=person}}}
+          {{>'/static/mustache/people/popover.mustache'}}
           &nbsp;
         </span>
       </a>

--- a/src/ggrc/assets/mustache/people/info.mustache
+++ b/src/ggrc/assets/mustache/people/info.mustache
@@ -68,7 +68,7 @@
       </div>
     </div><!-- tier-content end -->
 
-  {{{render '/static/mustache/custom_attributes/info.mustache' instance=instance}}}
+  {{>'/static/mustache/custom_attributes/info.mustache'}}
 
   </section>
 
@@ -78,7 +78,7 @@
         <em>
           Created at {{date created_at}}
             &nbsp;&nbsp;&nbsp;&nbsp;
-          Modified by {{#using person=modified_by}}{{{render '/static/mustache/people/popover.mustache' person=person}}}{{/using}} on {{date updated_at}}
+          Modified by {{#using person=modified_by}}{{>'/static/mustache/people/popover.mustache'}}{{/using}} on {{date updated_at}}
         </em>
         </small>
       </p>

--- a/src/ggrc/assets/mustache/people/info.mustache
+++ b/src/ggrc/assets/mustache/people/info.mustache
@@ -12,7 +12,7 @@
   <section class="info{{#is_info_pin}} sticky-info-panel{{/is_info_pin}}">
 
     {{#is_info_pin}}
-      <info-pin-buttons class="details-wrap" maximized="maximized" on-change-maximized-state="onChangeMaximizedState" on-close="onClose"></info-pin-buttons>
+      <info-pin-buttons class="details-wrap" maximized="maximized" on-change-maximized-state="@onChangeMaximizedState" on-close="@onClose"></info-pin-buttons>
     {{/is_info_pin}}
 
     <div class="tier-content">

--- a/src/ggrc/assets/mustache/people/object_list.mustache
+++ b/src/ggrc/assets/mustache/people/object_list.mustache
@@ -168,7 +168,9 @@
               </div>
             </div>
           </div>
-          {{{render '/static/mustache/custom_attributes/info.mustache' instance=this}}}
+          {{#using instance=this}}
+          {{>'/static/mustache/custom_attributes/info.mustache'}}
+          {{/using}}
         </div>
       </div><!-- tier 2 end -->
     </li>

--- a/src/ggrc/assets/mustache/people/tier2_content.mustache
+++ b/src/ggrc/assets/mustache/people/tier2_content.mustache
@@ -14,5 +14,5 @@
       </p>
     </div>
   {{/if}}
-  {{{render '/static/mustache/base_objects/mappings_detail.mustache' result=result parent_instance=parent_instance}}}
+  {{>'/static/mustache/base_objects/mappings_detail.mustache'}}
 </div>

--- a/src/ggrc/assets/mustache/policies/info.mustache
+++ b/src/ggrc/assets/mustache/policies/info.mustache
@@ -7,7 +7,7 @@
   <section class="info{{#is_info_pin}} sticky-info-panel{{/is_info_pin}}">
 
     {{#is_info_pin}}
-      <info-pin-buttons class="details-wrap" maximized="maximized" on-change-maximized-state="onChangeMaximizedState" on-close="onClose"></info-pin-buttons>
+      <info-pin-buttons class="details-wrap" maximized="maximized" on-change-maximized-state="@onChangeMaximizedState" on-close="@onClose"></info-pin-buttons>
     {{/is_info_pin}}
 
     {{> /static/mustache/base_objects/info-pane-utility.mustache}}

--- a/src/ggrc/assets/mustache/policies/info.mustache
+++ b/src/ggrc/assets/mustache/policies/info.mustache
@@ -13,11 +13,11 @@
     {{> /static/mustache/base_objects/info-pane-utility.mustache}}
 
     <div class="tier-content">
-      {{{render '/static/mustache/base_objects/general_info.mustache' instance=instance}}}
-      {{{render '/static/mustache/base_objects/description.mustache' instance=instance}}}
-      {{{render '/static/mustache/base_objects/notes.mustache' instance=instance}}}
-      {{{render '/static/mustache/base_objects/contacts.mustache' instance=instance}}}
-      {{{render '/static/mustache/base_objects/urls.mustache' instance=instance}}}
+      {{>'/static/mustache/base_objects/general_info.mustache'}}
+      {{>'/static/mustache/base_objects/description.mustache'}}
+      {{>'/static/mustache/base_objects/notes.mustache'}}
+      {{>'/static/mustache/base_objects/contacts.mustache'}}
+      {{>'/static/mustache/base_objects/urls.mustache'}}
 
       <div class="custom-attr-wrap">
         <div class="row-fluid">
@@ -80,7 +80,7 @@
       </div><!-- custom-attr-wrap end -->
     </div><!-- tier-content end -->
 
-  {{{render '/static/mustache/custom_attributes/info.mustache' instance=instance}}}
+  {{>'/static/mustache/custom_attributes/info.mustache'}}
 
   </section>
 
@@ -90,7 +90,7 @@
         <em>
           Created at {{date created_at}}
           &nbsp;&nbsp;&nbsp;&nbsp;
-          Modified by {{#using person=modified_by}}{{{render '/static/mustache/people/popover.mustache' person=person}}}{{/using}} on {{date updated_at}}
+          Modified by {{#using person=modified_by}}{{>'/static/mustache/people/popover.mustache'}}{{/using}} on {{date updated_at}}
         </em>
       </small>
     </p>

--- a/src/ggrc/assets/mustache/processes/info.mustache
+++ b/src/ggrc/assets/mustache/processes/info.mustache
@@ -7,7 +7,7 @@
   <section class="info{{#is_info_pin}} sticky-info-panel{{/is_info_pin}}">
 
     {{#is_info_pin}}
-      <info-pin-buttons class="details-wrap" maximized="maximized" on-change-maximized-state="onChangeMaximizedState" on-close="onClose"></info-pin-buttons>
+      <info-pin-buttons class="details-wrap" maximized="maximized" on-change-maximized-state="@onChangeMaximizedState" on-close="@onClose"></info-pin-buttons>
     {{/is_info_pin}}
 
     {{> /static/mustache/base_objects/info-pane-utility.mustache}}

--- a/src/ggrc/assets/mustache/processes/info.mustache
+++ b/src/ggrc/assets/mustache/processes/info.mustache
@@ -13,11 +13,11 @@
     {{> /static/mustache/base_objects/info-pane-utility.mustache}}
 
     <div class="tier-content">
-      {{{render '/static/mustache/base_objects/general_info.mustache' instance=instance}}}
-      {{{render '/static/mustache/base_objects/description.mustache' instance=instance}}}
-      {{{render '/static/mustache/base_objects/notes.mustache' instance=instance}}}
-      {{{render '/static/mustache/base_objects/contacts.mustache' instance=instance}}}
-      {{{render '/static/mustache/base_objects/urls.mustache' instance=instance}}}
+      {{>'/static/mustache/base_objects/general_info.mustache'}}
+      {{>'/static/mustache/base_objects/description.mustache'}}
+      {{>'/static/mustache/base_objects/notes.mustache'}}
+      {{>'/static/mustache/base_objects/contacts.mustache'}}
+      {{>'/static/mustache/base_objects/urls.mustache'}}
 
       <div class="custom-attr-wrap">
         <div class="row-fluid">
@@ -81,7 +81,7 @@
       </div><!-- custom-attr-wrap end -->
     </div><!-- tier-content end -->
 
-  {{{render '/static/mustache/custom_attributes/info.mustache' instance=instance}}}
+  {{>'/static/mustache/custom_attributes/info.mustache'}}
 
   </section>
 
@@ -91,7 +91,7 @@
         <em>
           Created at {{date created_at}}
           &nbsp;&nbsp;&nbsp;&nbsp;
-          Modified by {{#using person=modified_by}}{{{render '/static/mustache/people/popover.mustache' person=person}}}{{/using}} on {{date updated_at}}
+          Modified by {{#using person=modified_by}}{{>'/static/mustache/people/popover.mustache'}}{{/using}} on {{date updated_at}}
         </em>
       </small>
     </p>

--- a/src/ggrc/assets/mustache/products/info.mustache
+++ b/src/ggrc/assets/mustache/products/info.mustache
@@ -7,7 +7,7 @@
   <section class="info{{#is_info_pin}} sticky-info-panel{{/is_info_pin}}">
 
     {{#is_info_pin}}
-      <info-pin-buttons class="details-wrap" maximized="maximized" on-change-maximized-state="onChangeMaximizedState" on-close="onClose"></info-pin-buttons>
+      <info-pin-buttons class="details-wrap" maximized="maximized" on-change-maximized-state="@onChangeMaximizedState" on-close="@onClose"></info-pin-buttons>
     {{/is_info_pin}}
 
     {{> /static/mustache/base_objects/info-pane-utility.mustache}}

--- a/src/ggrc/assets/mustache/products/info.mustache
+++ b/src/ggrc/assets/mustache/products/info.mustache
@@ -13,11 +13,11 @@
     {{> /static/mustache/base_objects/info-pane-utility.mustache}}
 
     <div class="tier-content">
-      {{{render '/static/mustache/base_objects/general_info.mustache' instance=instance}}}
-      {{{render '/static/mustache/base_objects/description.mustache' instance=instance}}}
-      {{{render '/static/mustache/base_objects/notes.mustache' instance=instance}}}
-      {{{render '/static/mustache/base_objects/contacts.mustache' instance=instance}}}
-      {{{render '/static/mustache/base_objects/urls.mustache' instance=instance}}}
+      {{>'/static/mustache/base_objects/general_info.mustache'}}
+      {{>'/static/mustache/base_objects/description.mustache'}}
+      {{>'/static/mustache/base_objects/notes.mustache'}}
+      {{>'/static/mustache/base_objects/contacts.mustache'}}
+      {{>'/static/mustache/base_objects/urls.mustache'}}
 
       <div class="custom-attr-wrap">
         <div class="row-fluid">
@@ -82,7 +82,7 @@
       </div><!-- custom-attr-wrap end -->
     </div><!-- tier-content end -->
 
-  {{{render '/static/mustache/custom_attributes/info.mustache' instance=instance}}}
+  {{>'/static/mustache/custom_attributes/info.mustache'}}
 
   </section>
 
@@ -92,7 +92,7 @@
         <em>
           Created at {{date created_at}}
           &nbsp;&nbsp;&nbsp;&nbsp;
-          Modified by {{#using person=modified_by}}{{{render '/static/mustache/people/popover.mustache' person=person}}}{{/using}} on {{date updated_at}}
+          Modified by {{#using person=modified_by}}{{>'/static/mustache/people/popover.mustache'}}{{/using}} on {{date updated_at}}
         </em>
       </small>
     </p>

--- a/src/ggrc/assets/mustache/programs/info.mustache
+++ b/src/ggrc/assets/mustache/programs/info.mustache
@@ -13,9 +13,9 @@
     {{> /static/mustache/base_objects/info-pane-utility.mustache}}
 
     <div class="tier-content">
-      {{{render '/static/mustache/base_objects/general_info.mustache' instance=instance}}}
-      {{{render '/static/mustache/base_objects/description.mustache' instance=instance}}}
-      {{{render '/static/mustache/base_objects/notes.mustache' instance=instance}}}
+      {{>'/static/mustache/base_objects/general_info.mustache'}}
+      {{>'/static/mustache/base_objects/description.mustache'}}
+      {{>'/static/mustache/base_objects/notes.mustache'}}
       {{{render '/static/mustache/base_objects/contacts.mustache' is_program=true instance=instance}}}
       {{{render '/static/mustache/base_objects/urls.mustache' is_program=true instance=instance}}}
 
@@ -68,7 +68,7 @@
             </div>
           </div>
         </div>
-        {{{render '/static/mustache/custom_attributes/info.mustache' instance=instance}}}
+        {{>'/static/mustache/custom_attributes/info.mustache'}}
       </div><!-- custom-attr-wrap end -->
     </div><!-- tier-content end -->
 
@@ -80,7 +80,7 @@
         <em>
           Created at {{date created_at}}
           &nbsp;&nbsp;&nbsp;&nbsp;
-          Modified by {{#using person=modified_by}}{{{render '/static/mustache/people/popover.mustache' person=person}}}{{/using}} on {{date updated_at}}
+          Modified by {{#using person=modified_by}}{{>'/static/mustache/people/popover.mustache'}}{{/using}} on {{date updated_at}}
         </em>
       </small>
     </p>

--- a/src/ggrc/assets/mustache/programs/info.mustache
+++ b/src/ggrc/assets/mustache/programs/info.mustache
@@ -7,7 +7,7 @@
   <section class="info{{#is_info_pin}} sticky-info-panel{{/is_info_pin}}">
 
     {{#is_info_pin}}
-      <info-pin-buttons class="details-wrap" maximized="maximized" on-change-maximized-state="onChangeMaximizedState" on-close="onClose"></info-pin-buttons>
+      <info-pin-buttons class="details-wrap" maximized="maximized" on-change-maximized-state="@onChangeMaximizedState" on-close="@onClose"></info-pin-buttons>
     {{/is_info_pin}}
 
     {{> /static/mustache/base_objects/info-pane-utility.mustache}}

--- a/src/ggrc/assets/mustache/programs/tier2_content.mustache
+++ b/src/ggrc/assets/mustache/programs/tier2_content.mustache
@@ -6,8 +6,8 @@
 {{> /static/mustache/base_objects/dropdown_menu_tier2.mustache}}
 
 <div class="tier-content">
-  {{{render '/static/mustache/base_objects/general_info.mustache' instance=instance }}}
-  {{{render '/static/mustache/base_objects/description.mustache' instance=instance}}}
+  {{>'/static/mustache/base_objects/general_info.mustache'}}
+  {{>'/static/mustache/base_objects/description.mustache'}}
   {{{renderLive '/static/mustache/base_objects/notes_and_code.mustache' instance=instance}}}
   {{{renderLive '/static/mustache/base_objects/mappings_detail.mustache' result=result parent_instance=parent_instance}}}
   {{^if_equals instance.class.table_singular 'person'}}

--- a/src/ggrc/assets/mustache/sections/tier2_content.mustache
+++ b/src/ggrc/assets/mustache/sections/tier2_content.mustache
@@ -80,8 +80,8 @@
 {{/if_helpers}}
 
 <div class="tier-content">
-  {{{render '/static/mustache/base_objects/general_info.mustache' instance=instance }}}
-  {{{render '/static/mustache/base_objects/description.mustache' instance=instance}}}
+  {{>'/static/mustache/base_objects/general_info.mustache'}}
+  {{>'/static/mustache/base_objects/description.mustache'}}
   <div class="row-fluid wrap-row">
     <div class="span12">
       <h6>

--- a/src/ggrc/assets/mustache/systems/info.mustache
+++ b/src/ggrc/assets/mustache/systems/info.mustache
@@ -7,7 +7,7 @@
   <section class="info{{#is_info_pin}} sticky-info-panel{{/is_info_pin}}">
 
     {{#is_info_pin}}
-      <info-pin-buttons class="details-wrap" maximized="maximized" on-change-maximized-state="onChangeMaximizedState" on-close="onClose"></info-pin-buttons>
+      <info-pin-buttons class="details-wrap" maximized="maximized" on-change-maximized-state="@onChangeMaximizedState" on-close="@onClose"></info-pin-buttons>
     {{/is_info_pin}}
 
     {{> /static/mustache/base_objects/info-pane-utility.mustache}}

--- a/src/ggrc/assets/mustache/systems/info.mustache
+++ b/src/ggrc/assets/mustache/systems/info.mustache
@@ -13,11 +13,11 @@
     {{> /static/mustache/base_objects/info-pane-utility.mustache}}
 
     <div class="tier-content">
-      {{{render '/static/mustache/base_objects/general_info.mustache' instance=instance}}}
-      {{{render '/static/mustache/base_objects/description.mustache' instance=instance}}}
-      {{{render '/static/mustache/base_objects/notes.mustache' instance=instance}}}
-      {{{render '/static/mustache/base_objects/contacts.mustache' instance=instance}}}
-      {{{render '/static/mustache/base_objects/urls.mustache' instance=instance}}}
+      {{>'/static/mustache/base_objects/general_info.mustache'}}
+      {{>'/static/mustache/base_objects/description.mustache'}}
+      {{>'/static/mustache/base_objects/notes.mustache'}}
+      {{>'/static/mustache/base_objects/contacts.mustache'}}
+      {{>'/static/mustache/base_objects/urls.mustache'}}
 
       <div class="custom-attr-wrap">
         <div class="row-fluid">
@@ -81,7 +81,7 @@
       </div><!-- custom-attr-wrap end -->
     </div><!-- tier-content end -->
 
-  {{{render '/static/mustache/custom_attributes/info.mustache' instance=instance}}}
+  {{>'/static/mustache/custom_attributes/info.mustache'}}
 
   </section>
 
@@ -91,7 +91,7 @@
         <em>
           Created at {{date created_at}}
           &nbsp;&nbsp;&nbsp;&nbsp;
-          Modified by {{#using person=modified_by}}{{{render '/static/mustache/people/popover.mustache' person=person}}}{{/using}} on {{date updated_at}}
+          Modified by {{#using person=modified_by}}{{>'/static/mustache/people/popover.mustache'}}{{/using}} on {{date updated_at}}
         </em>
       </small>
     </p>

--- a/src/ggrc/models/custom_attribute_value.py
+++ b/src/ggrc/models/custom_attribute_value.py
@@ -66,16 +66,8 @@ class CustomAttributeValue(Base, db.Model):
       "Map:Person": lambda self: self._validate_map_person(),
   }
 
-  _custom_publish = {
-      "attribute_value": lambda self: self._publish_attribute_value(),
-  }
-  _custom_update = {
-      "attribute_value": lambda self, val: self._update_attribute_value(val),
-  }
-
   # formats to represent Date-type values
   DATE_FORMAT_DB = "%Y-%m-%d"
-  DATE_FORMAT_JSON = "%m/%d/%Y"
 
   @property
   def latest_revision(self):
@@ -273,9 +265,12 @@ class CustomAttributeValue(Base, db.Model):
             CustomAttributeDefinition.ValidTypes.DATE):
       # convert the date formats for dates
       if self.attribute_value:
+        # Conversion is done just to perform validation, but simplify it
+        # because frontend now actually knows how to properly serialize dates
+        # and thus not "conversion attempt" is necessary, just the validation.
         self.attribute_value = utils.convert_date_format(
             self.attribute_value,
-            CustomAttributeValue.DATE_FORMAT_JSON,
+            CustomAttributeValue.DATE_FORMAT_DB,
             CustomAttributeValue.DATE_FORMAT_DB,
         )
 
@@ -413,58 +408,3 @@ class CustomAttributeValue(Base, db.Model):
           (make_flags(mask)
            for mask in cad.multi_choice_mandatory.split(",")),
       ))
-
-  def _publish_attribute_value(self):
-    """Return value serialized for JSON.
-
-    If self is a Date-type CAV, convert it to MM/DD/YYYY.
-    """
-
-    from ggrc.models import CustomAttributeDefinition
-
-    result = self.attribute_value
-    literal_date = CustomAttributeDefinition.ValidTypes.DATE
-
-    self_is_date = self.custom_attribute.attribute_type == literal_date
-    if self_is_date and self.attribute_value:
-      try:
-        result = utils.convert_date_format(self.attribute_value,
-                                           self.DATE_FORMAT_DB,
-                                           self.DATE_FORMAT_JSON)
-      except ValueError:
-        # invalid format or not a date, don't convert
-        pass
-
-    return result
-
-  def _update_attribute_value(self, new_value):
-    """Update value from received JSON.
-
-    If self is a Date-type CAV, convert the received value to YYYY-MM-DD.
-    """
-
-    from ggrc.models import CustomAttributeDefinition
-
-    literal_date = CustomAttributeDefinition.ValidTypes.DATE
-
-    # pylint: disable=access-member-before-definition
-    # pylint: disable=attribute-defined-outside-init
-    # false positives on the next block; the author doesn't like that block too
-    if self.custom_attribute is None:
-      # self is newly created and is not yet flushed to the db
-      # manually store self.custom_attribute because it is cached as None until
-      # flush & expire
-      self.custom_attribute = (db.session.query(CustomAttributeDefinition)
-                               .filter_by(id=self.custom_attribute_id).one())
-
-    self_is_date = self.custom_attribute.attribute_type == literal_date
-    if self_is_date and new_value:
-      try:
-        new_value = utils.convert_date_format(new_value,
-                                              self.DATE_FORMAT_JSON,
-                                              self.DATE_FORMAT_DB)
-      except ValueError:
-        # invalid format or not a date, don't convert
-        pass
-
-    self.attribute_value = new_value

--- a/src/ggrc/models/custom_attribute_value.py
+++ b/src/ggrc/models/custom_attribute_value.py
@@ -29,6 +29,7 @@ class CustomAttributeValue(Base, db.Model):
       'attributable_id',
       'attributable_type',
       'attribute_value',
+      PublishOnly('attribute_type'),
       'attribute_object',
       PublishOnly('preconditions_failed'),
   ]
@@ -45,6 +46,10 @@ class CustomAttributeValue(Base, db.Model):
   attributable_id = db.Column(db.Integer)
   attributable_type = db.Column(db.String)
   attribute_value = db.Column(db.String)
+
+  @computed_property
+  def attribute_type(self):
+    return self.custom_attribute.attribute_type
 
   # When the attibute is of a mapping type this will hold the id of the mapped
   # object while attribute_value will hold the type name.

--- a/src/ggrc_basic_permissions/assets/mustache/ggrc_basic_permissions/people_roles/authorizations_by_person_tree.mustache
+++ b/src/ggrc_basic_permissions/assets/mustache/ggrc_basic_permissions/people_roles/authorizations_by_person_tree.mustache
@@ -13,7 +13,7 @@
                 <div class="span4">
                   <div class="title tree-title-area">
                     {{#using person=instance}}
-                      {{> '/static/mustache/people/popover.mustache'}}
+                      {{>'/static/mustache/people/popover.mustache'}}
                     {{/using}}
                   </div>
                 </div>

--- a/src/ggrc_basic_permissions/assets/mustache/ggrc_basic_permissions/people_roles/authorizations_by_person_tree.mustache
+++ b/src/ggrc_basic_permissions/assets/mustache/ggrc_basic_permissions/people_roles/authorizations_by_person_tree.mustache
@@ -12,7 +12,9 @@
               <div class="row-fluid">
                 <div class="span4">
                   <div class="title tree-title-area">
-                    {{{render '/static/mustache/people/popover.mustache' person=instance}}}
+                    {{#using person=instance}}
+                      {{> '/static/mustache/people/popover.mustache'}}
+                    {{/using}}
                   </div>
                 </div>
                 <div class="span2">
@@ -32,9 +34,9 @@
                               {{#if_helpers '\
                                 #if_equals' roles.0.role.permission_summary 'Mapped' '\
                                 and ^if_equals' roles.length 1}}
-                                {{pretty_role_name roles.1.role.permission_summary}}
+                                {{pretty_role_name roles.1.role.name}}
                               {{else}}
-                                {{pretty_role_name roles.0.role.permission_summary}}
+                                {{pretty_role_name roles.0.role.name}}
                               {{/if_helpers}}
                               {{#roles.1}}
                                 {{#if_in_map roles 'role.permission_summary' 'Mapped'}}

--- a/src/ggrc_basic_permissions/assets/mustache/ggrc_basic_permissions/people_roles/info.mustache
+++ b/src/ggrc_basic_permissions/assets/mustache/ggrc_basic_permissions/people_roles/info.mustache
@@ -124,7 +124,7 @@
 
     <div class="row-fluid wrap-row">
       <div class="span12">
-        {{{render '/static/mustache/custom_attributes/info.mustache' instance=instance}}}
+        {{>'/static/mustache/custom_attributes/info.mustache'}}
       </div>
     </div>
 

--- a/src/ggrc_basic_permissions/assets/mustache/ggrc_basic_permissions/people_roles/info.mustache
+++ b/src/ggrc_basic_permissions/assets/mustache/ggrc_basic_permissions/people_roles/info.mustache
@@ -6,7 +6,7 @@
 <section class="info{{#is_info_pin}} sticky-info-panel{{/is_info_pin}}">
 
   {{#is_info_pin}}
-    <info-pin-buttons class="details-wrap" maximized="maximized" on-change-maximized-state="onChangeMaximizedState" on-close="onClose"></info-pin-buttons>
+    <info-pin-buttons class="details-wrap" maximized="maximized" on-change-maximized-state="@onChangeMaximizedState" on-close="@onClose"></info-pin-buttons>
   {{/is_info_pin}}
 
   <div class="info-pane-utility">

--- a/src/ggrc_risk_assessments/assets/mustache/risk_assessments/info.mustache
+++ b/src/ggrc_risk_assessments/assets/mustache/risk_assessments/info.mustache
@@ -12,8 +12,8 @@
   {{> /static/mustache/base_objects/info-pane-utility.mustache}}
 
   <div class="tier-content">
-    {{{render '/static/mustache/base_objects/general_info.mustache' instance=instance}}}
-    {{{render '/static/mustache/base_objects/description.mustache' instance=instance}}}
+    {{>'/static/mustache/base_objects/general_info.mustache'}}
+    {{>'/static/mustache/base_objects/description.mustache'}}
 
     <div class="row-fluid wrap-row">
       <div class="span12">
@@ -41,13 +41,13 @@
       <div class="span4">
         <h6>Risk Manager</h6>
         {{#using person=instance.ra_manager}}
-          {{{render '/static/mustache/people/popover.mustache'}}}
+          {{>'/static/mustache/people/popover.mustache'}}
         {{/using}}
       </div>
       <div class="span4">
         <h6>Risk Counsel</h6>
         {{#using person=instance.ra_counsel}}
-          {{{render '/static/mustache/people/popover.mustache'}}}
+          {{>'/static/mustache/people/popover.mustache'}}
         {{/using}}
       </div>
     </div>
@@ -104,5 +104,5 @@
 
   </div>
 
-  {{{render '/static/mustache/custom_attributes/info.mustache' instance=instance}}}
+  {{>'/static/mustache/custom_attributes/info.mustache'}}
 </div>

--- a/src/ggrc_risk_assessments/assets/mustache/risk_assessments/info.mustache
+++ b/src/ggrc_risk_assessments/assets/mustache/risk_assessments/info.mustache
@@ -6,7 +6,7 @@
 <section class="info{{#is_info_pin}} sticky-info-panel{{/is_info_pin}}">
 
   {{#is_info_pin}}
-    <info-pin-buttons class="details-wrap" maximized="maximized" on-change-maximized-state="onChangeMaximizedState" on-close="onClose"></info-pin-buttons>
+    <info-pin-buttons class="details-wrap" maximized="maximized" on-change-maximized-state="@onChangeMaximizedState" on-close="@onClose"></info-pin-buttons>
   {{/is_info_pin}}
 
   {{> /static/mustache/base_objects/info-pane-utility.mustache}}

--- a/src/ggrc_risks/assets/mustache/risks/info.mustache
+++ b/src/ggrc_risks/assets/mustache/risks/info.mustache
@@ -13,10 +13,10 @@
     {{> /static/mustache/base_objects/info-pane-utility.mustache}}
 
     <div class="tier-content">
-      {{{render '/static/mustache/base_objects/general_info.mustache' instance=instance}}}
-      {{{render '/static/mustache/base_objects/description.mustache' instance=instance}}}
-      {{{render '/static/mustache/base_objects/contacts.mustache' instance=instance}}}
-      {{{render '/static/mustache/base_objects/urls.mustache' instance=instance}}}
+      {{>'/static/mustache/base_objects/general_info.mustache'}}
+      {{>'/static/mustache/base_objects/description.mustache'}}
+      {{>'/static/mustache/base_objects/contacts.mustache'}}
+      {{>'/static/mustache/base_objects/urls.mustache'}}
 
       <div class="custom-attr-wrap">
         <div class="row-fluid">
@@ -69,7 +69,7 @@
       </div><!-- custom-attr-wrap end -->
     </div><!-- tier-content end -->
 
-  {{{render '/static/mustache/custom_attributes/info.mustache' instance=instance}}}
+  {{>'/static/mustache/custom_attributes/info.mustache'}}
 
   </section>
 
@@ -79,7 +79,7 @@
         <em>
           Created at {{date created_at}}
           &nbsp;&nbsp;&nbsp;&nbsp;
-          Modified by {{#using person=modified_by}}{{{render '/static/mustache/people/popover.mustache' person=person}}}{{/using}} on {{date updated_at}}
+          Modified by {{#using person=modified_by}}{{>'/static/mustache/people/popover.mustache'}}{{/using}} on {{date updated_at}}
         </em>
       </small>
     </p>

--- a/src/ggrc_risks/assets/mustache/risks/info.mustache
+++ b/src/ggrc_risks/assets/mustache/risks/info.mustache
@@ -7,7 +7,7 @@
   <section class="info{{#is_info_pin}} sticky-info-panel{{/is_info_pin}}">
 
     {{#is_info_pin}}
-      <info-pin-buttons class="details-wrap" maximized="maximized" on-change-maximized-state="onChangeMaximizedState" on-close="onClose"></info-pin-buttons>
+      <info-pin-buttons class="details-wrap" maximized="maximized" on-change-maximized-state="@onChangeMaximizedState" on-close="@onClose"></info-pin-buttons>
     {{/is_info_pin}}
 
     {{> /static/mustache/base_objects/info-pane-utility.mustache}}

--- a/src/ggrc_workflows/assets/javascripts/models/cycle_models.js
+++ b/src/ggrc_workflows/assets/javascripts/models/cycle_models.js
@@ -7,7 +7,7 @@
   var _mustachePath;
   var overdueCompute;
 
-  overdueCompute = can.compute(function (val) {
+  overdueCompute = function (val) {
     var date;
     var today = moment().startOf('day');
     var startOfDate;
@@ -21,7 +21,7 @@
       return '';
     }
     return 'overdue';
-  });
+  };
 
   function refreshAttr(instance, attr) {
     if (instance.attr(attr).reify().selfLink) {
@@ -471,7 +471,7 @@
         return object;
       });
     },
-    response_options_csv: can.compute(function (val) {
+    response_options_csv: function (val) {
       if (val != null) {
         this.attr(
           'response_options',
@@ -480,9 +480,9 @@
       } else {
         return (this.attr('response_options') || []).join(', ');
       }
-    }),
+    },
 
-    selected_response_options_csv: can.compute(function (val) {
+    selected_response_options_csv: function (val) {
       if (val != null) {
         this.attr(
           'selected_response_options',
@@ -491,6 +491,6 @@
       } else {
         return (this.attr('selected_response_options') || []).join(', ');
       }
-    })
+    }
   });
 })(window.can);

--- a/src/ggrc_workflows/assets/javascripts/models/helpers.js
+++ b/src/ggrc_workflows/assets/javascripts/models/helpers.js
@@ -4,7 +4,7 @@
 */
 
 (function (can, $, CMS) {
-  var ApprovalWorkflowErrors = can.compute(function () {
+  var ApprovalWorkflowErrors = function () {
     var errors = null;
     if (!this.attr('contact')) {
       errors = {
@@ -17,7 +17,7 @@
       });
     }
     return errors;
-  });
+  };
 
   can.Observe('CMS.ModelHelpers.CycleTask', {
     findInCacheById: function () {
@@ -65,7 +65,7 @@
           return CycleTask.save();
         }.bind(this));
     },
-    computed_errors: can.compute(function () {
+    computed_errors: function () {
       var errors = null;
       if (!this.attr('title')) {
         errors = {
@@ -73,7 +73,7 @@
         };
       }
       return errors;
-    })
+    }
   });
 
   can.Observe('CMS.ModelHelpers.ApprovalWorkflow', {

--- a/src/ggrc_workflows/assets/javascripts/models/task_group.js
+++ b/src/ggrc_workflows/assets/javascripts/models/task_group.js
@@ -212,7 +212,7 @@
       }
     },
 
-    response_options_csv: can.compute(function (val) {
+    response_options_csv: function (val) {
       var isSet = val && val.length;
       var responseOptions = this.attr('response_options');
       var options = isSet ?
@@ -226,6 +226,6 @@
       } else {
         return options.join(', ');
       }
-    })
+    }
   });
 })(window.can);

--- a/src/ggrc_workflows/assets/javascripts/models/workflow.js
+++ b/src/ggrc_workflows/assets/javascripts/models/workflow.js
@@ -201,7 +201,7 @@
     // start day of month, affects start_date.
     //  Use when month number doesn't matter or is
     //  selectable.
-    start_day_of_month: can.compute(function(val) {
+    start_day_of_month: function(val) {
       var newdate;
       if(val) {
         while(val.isComputed) {
@@ -224,12 +224,12 @@
           return null;
         }
       }
-    }),
+    },
 
     // end day of month, affects end_date.
     //  Use when month number doesn't matter or is
     //  selectable.
-    end_day_of_month: can.compute(function(val) {
+    end_day_of_month: function(val) {
       var newdate;
       if(val) {
         while(val.isComputed) {
@@ -252,12 +252,12 @@
           return null;
         }
       }
-    }),
+    },
 
     // start month of quarter, affects start_date.
     //  Sets month to be a 31-day month in the chosen quarterly cycle:
     //  1 for Jan-Apr-Jul-Oct, 2 for Feb-May-Aug-Nov, 3 for Mar-Jun-Sep-Dec
-    start_month_of_quarter: can.compute(function(val) {
+    start_month_of_quarter: function(val) {
       var newdate;
       var month_lookup = [0, 4, 2]; //31-day months in quarter cycles: January, May, March
 
@@ -273,12 +273,12 @@
           return null;
         }
       }
-    }),
+    },
 
     // end month of quarter, affects end_date.
     //  Sets month to be a 31-day month in the chosen quarterly cycle:
     //  1 for Jan-Apr-Jul-Oct, 2 for Feb-May-Aug-Nov, 3 for Mar-Jun-Sep-Dec
-    end_month_of_quarter: can.compute(function(val) {
+    end_month_of_quarter: function(val) {
       var newdate;
       var month_lookup = [0, 7, 2]; //31-day months in quarter cycles: January, May, March
 
@@ -294,12 +294,12 @@
           return null;
         }
       }
-    }),
+    },
 
     // start month of yesr, affects start_date.
     //  Sets month to the chosen month, and adjusts
     //  day of month to be within chosen month
-    start_month_of_year: can.compute(function(val) {
+    start_month_of_year: function(val) {
       var newdate;
       if(val) {
         if(val > 12) {
@@ -319,12 +319,12 @@
           return null;
         }
       }
-    }),
+    },
 
     // end month of yesr, affects end_date.
     //  Sets month to the chosen month, and adjusts
     //  day of month to be within chosen month
-    end_month_of_year: can.compute(function(val) {
+    end_month_of_year: function(val) {
       var newdate;
       if(val) {
         if(val > 12) {
@@ -344,13 +344,13 @@
           return null;
         }
       }
-    }),
+    },
 
     // start day of week, affects start_date.
     //  Sets day of month to the first day of the
     //  month that is the selected day of the week
     //  Sunday is 0, Saturday is 6
-    start_day_of_week: can.compute(function(val) {
+    start_day_of_week: function(val) {
       var newdate;
       if(val) {
         val = +val;
@@ -365,13 +365,13 @@
           return null;
         }
       }
-    }),
+    },
 
     // end day of week, affects end_date.
     //  Sets day of month to the first day of the
     //  month that is the selected day of the week
     //  Sunday is 0, Saturday is 6
-    end_day_of_week: can.compute(function(val) {
+    end_day_of_week: function(val) {
       var newdate;
       if(val) {
         val = +val;
@@ -386,7 +386,7 @@
           return null;
         }
       }
-    })
+    }
   });
 
 })(window.can);

--- a/src/ggrc_workflows/assets/javascripts/models/workflow.js
+++ b/src/ggrc_workflows/assets/javascripts/models/workflow.js
@@ -139,28 +139,28 @@
               start = moment().isoWeekday(task.relative_start_day);
               end = moment().isoWeekday(task.relative_end_day);
               if (_afterOrSame(start, end)) {
-                end.add('w', 1);
+                end.add(1, 'w');
               }
               break;
             case "monthly":
               start = moment().date(task.relative_start_day);
               end = moment().date(task.relative_end_day);
               if (_afterOrSame(start, end)) {
-                end.add('M', 1);
+                end.add(1, 'M');
               }
               break;
             case "quarterly":
-              start = _currentQuarter().date(task.relative_start_day).add('M', task.relative_start_month-1);
-              end = _currentQuarter().date(task.relative_end_day).add('M', task.relative_end_month-1);
+              start = _currentQuarter().date(task.relative_start_day).add(task.relative_start_month-1, 'M');
+              end = _currentQuarter().date(task.relative_end_day).add(task.relative_end_month-1, 'M');
               if (_afterOrSame(start, end)) {
-                end.add('q', 1);
+                end.add(1, 'q');
               }
               break;
             case "annually":
               start = moment().date(task.relative_start_day).month(task.relative_start_month-1);
               end = moment().date(task.relative_end_day).month(task.relative_end_month-1);
               if (_afterOrSame(start, end)) {
-                end.add('y', 1);
+                end.add(1, 'y');
               }
               break;
           }

--- a/src/ggrc_workflows/assets/mustache/base_objects/approval_link.mustache
+++ b/src/ggrc_workflows/assets/mustache/base_objects/approval_link.mustache
@@ -12,7 +12,7 @@
         Reviewed on {{instance.updated_at}} <br />
         and approved by
         {{#using person=instance.modified_by}}
-          {{{> '/static/mustache/people/popover.mustache'}}}
+          {{>'/static/mustache/people/popover.mustache'}}
         {{/using}}
       </span>
       {{/last_approved}}

--- a/src/ggrc_workflows/assets/mustache/cycle_task_entries/tree.mustache
+++ b/src/ggrc_workflows/assets/mustache/cycle_task_entries/tree.mustache
@@ -43,7 +43,7 @@
     {{/if_equals}}
     <span class="entry-author">
       Modified by
-      {{#using person=instance.modified_by}}{{{render '/static/mustache/people/popover.mustache' person=person}}}{{/using}}
+      {{#using person=instance.modified_by}}{{>'/static/mustache/people/popover.mustache'}}{{/using}}
       {{#if instance.created_at}}on {{date instance.created_at}}{{/if}}
     </span>
   </div>

--- a/src/ggrc_workflows/assets/mustache/cycle_task_group_object_tasks/info.mustache
+++ b/src/ggrc_workflows/assets/mustache/cycle_task_group_object_tasks/info.mustache
@@ -46,7 +46,7 @@
     </div>
 
     <div class="tier-content">
-      {{{render '/static/mustache/base_objects/general_info.mustache' instance=instance}}}
+      {{>'/static/mustache/base_objects/general_info.mustache'}}
 
       <div class="row-fluid wrap-row">
         <div class="span6">
@@ -115,7 +115,7 @@
 
       <div class="row-fluid wrap-row">
         <div class="span12">
-          {{{render "/static/mustache/base_templates/mapped_objects.mustache" instance=instance }}}
+          {{>'/static/mustache/base_templates/mapped_objects.mustache'}}
         </div>
       </div>
 
@@ -210,7 +210,7 @@
           {{/with_mapping_count}}
 
           <ul class="add-task-comment">
-            {{{render '/static/mustache/cycle_task_entries/tree_footer.mustache' parent_instance=instance}}}
+            {{>'/static/mustache/cycle_task_entries/tree_footer.mustache'}}
           </ul>
         </div>
       </div>

--- a/src/ggrc_workflows/assets/mustache/cycle_task_group_object_tasks/info.mustache
+++ b/src/ggrc_workflows/assets/mustache/cycle_task_group_object_tasks/info.mustache
@@ -8,7 +8,7 @@
   <section class="info{{#is_info_pin}} sticky-info-panel{{/is_info_pin}}">
 
     {{#is_info_pin}}
-      <info-pin-buttons class="details-wrap" maximized="maximized" on-change-maximized-state="onChangeMaximizedState" on-close="onClose"></info-pin-buttons>
+      <info-pin-buttons class="details-wrap" maximized="maximized" on-change-maximized-state="@onChangeMaximizedState" on-close="@onClose"></info-pin-buttons>
     {{/is_info_pin}}
 
     <div class="info-pane-utility">

--- a/src/ggrc_workflows/assets/mustache/cycle_task_group_objects/info.mustache
+++ b/src/ggrc_workflows/assets/mustache/cycle_task_group_objects/info.mustache
@@ -8,7 +8,7 @@
     <section class="info{{#is_info_pin}} sticky-info-panel{{/is_info_pin}}">
 
       {{#is_info_pin}}
-        <info-pin-buttons class="details-wrap" maximized="maximized" on-change-maximized-state="onChangeMaximizedState" on-close="onClose"></info-pin-buttons>
+        <info-pin-buttons class="details-wrap" maximized="maximized" on-change-maximized-state="@onChangeMaximizedState" on-close="@onClose"></info-pin-buttons>
       {{/is_info_pin}}
 
       <div class="info-pane-utility">

--- a/src/ggrc_workflows/assets/mustache/cycle_task_groups/info.mustache
+++ b/src/ggrc_workflows/assets/mustache/cycle_task_groups/info.mustache
@@ -12,7 +12,7 @@
     {{/is_info_pin}}
 
     <div class="tier-content">
-      {{{render '/static/mustache/base_objects/general_info.mustache' instance=instance}}}
+      {{>'/static/mustache/base_objects/general_info.mustache'}}
       <div class="row-fluid wrap-row">
         <div class="span12">
           <h6>{{instance.class.title_singular}} description</h6>

--- a/src/ggrc_workflows/assets/mustache/cycle_task_groups/info.mustache
+++ b/src/ggrc_workflows/assets/mustache/cycle_task_groups/info.mustache
@@ -8,7 +8,7 @@
   <section class="info{{#is_info_pin}} sticky-info-panel{{/is_info_pin}}">
 
     {{#is_info_pin}}
-      <info-pin-buttons class="details-wrap" maximized="maximized" on-change-maximized-state="onChangeMaximizedState" on-close="onClose"></info-pin-buttons>
+      <info-pin-buttons class="details-wrap" maximized="maximized" on-change-maximized-state="@onChangeMaximizedState" on-close="@onClose"></info-pin-buttons>
     {{/is_info_pin}}
 
     <div class="tier-content">

--- a/src/ggrc_workflows/assets/mustache/cycles/info.mustache
+++ b/src/ggrc_workflows/assets/mustache/cycles/info.mustache
@@ -38,7 +38,7 @@
   </div>
 
   <div class="tier-content">
-    {{{render '/static/mustache/base_objects/general_info.mustache' instance=instance}}}
+    {{>'/static/mustache/base_objects/general_info.mustache'}}
 
     <div class="row-fluid wrap-row">
       <div class="span12">
@@ -81,7 +81,7 @@
   </div>
   <div class="row-fluid">
     <div class="span12">
-      {{{render '/static/mustache/custom_attributes/info.mustache' instance=instance}}}
+      {{>'/static/mustache/custom_attributes/info.mustache'}}
     </div>
   </div>
 

--- a/src/ggrc_workflows/assets/mustache/cycles/info.mustache
+++ b/src/ggrc_workflows/assets/mustache/cycles/info.mustache
@@ -6,7 +6,7 @@
 <section class="info{{#is_info_pin}} sticky-info-panel{{/is_info_pin}}">
 
   {{#is_info_pin}}
-    <info-pin-buttons class="details-wrap" maximized="maximized" on-change-maximized-state="onChangeMaximizedState" on-close="onClose"></info-pin-buttons>
+    <info-pin-buttons class="details-wrap" maximized="maximized" on-change-maximized-state="@onChangeMaximizedState" on-close="@onClose"></info-pin-buttons>
   {{/is_info_pin}}
 
   <div class="info-pane-utility">

--- a/src/ggrc_workflows/assets/mustache/task_group_tasks/modal_content.mustache
+++ b/src/ggrc_workflows/assets/mustache/task_group_tasks/modal_content.mustache
@@ -102,9 +102,9 @@
             Starts every
             <span class="required">*</span>
           </span>
-          <select name="relative_start_day" class="input-medium" tabindex="4">
-            {{#iterate 1 "Monday" 2 "Tuesday" 3 "Wednesday" 4 "Thursday" 5 "Friday" step=2 listen=instance.relative_start_day}}
-            <option value="{{iterator_0}}" {{#if_equals instance.relative_start_day iterator_0}}selected="true"{{/if_equals}}>{{iterator_1}}</option>
+          <select name="relative_start_day" class="input-medium" can-value="instance.relative_start_day" tabindex="4">
+            {{#iterate 1 "Monday" 2 "Tuesday" 3 "Wednesday" 4 "Thursday" 5 "Friday" step=2}}
+            <option value="{{iterator_0}}">{{iterator_1}}</option>
             {{/iterate}}
           </select>
         </label>
@@ -113,9 +113,9 @@
             Due every
             <span class="required">*</span>
           </span>
-          <select name="relative_end_day" class="input-medium" tabindex="5">
-            {{#iterate 1 "Monday" 2 "Tuesday" 3 "Wednesday" 4 "Thursday" 5 "Friday" step=2 listen=instance.relative_end_day}}
-            <option value="{{iterator_0}}" {{#if_equals instance.relative_end_day iterator_0}}selected="true"{{/if_equals}}>{{iterator_1}}</option>
+          <select name="relative_end_day" class="input-medium" can-value="instance.relative_end_day" tabindex="5">
+            {{#iterate 1 "Monday" 2 "Tuesday" 3 "Wednesday" 4 "Thursday" 5 "Friday" step=2}}
+            <option value="{{iterator_0}}">{{iterator_1}}</option>
             {{/iterate}}
           </select>
         </label>
@@ -132,9 +132,9 @@
             Starts every
             <span class="required">*</span>
           </span>
-          <select name="relative_start_day" class="input-small" tabindex="4">
-            {{#iterate 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 listen=instance.relative_start_day}}
-            <option {{#if_equals instance.relative_start_day iterator}}selected="selected"{{/if_equals}}>{{iterator}}</option>
+          <select name="relative_start_day" class="input-small" can-value="instance.relative_start_day" tabindex="4">
+            {{#iterate 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31}}
+            <option value="{{iterator}}">{{iterator}}</option>
             {{/iterate}}
           </select>
         </label>
@@ -143,9 +143,9 @@
             Due every
             <span class="required">*</span>
           </span>
-          <select name="relative_end_day" class="input-small" tabindex="5">
-            {{#iterate 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 listen=instance.relative_end_day}}
-            <option {{#if_equals instance.relative_end_day iterator}}selected="selected"{{/if_equals}}>{{iterator}}</option>
+          <select name="relative_end_day" class="input-small" can-value="instance.relative_end_day" tabindex="5">
+            {{#iterate 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31}}
+            <option value="{{iterator}}">{{iterator}}</option>
             {{/iterate}}
           </select>
         </label>
@@ -162,14 +162,14 @@
             Starts
             <span class="required">*</span>
           </span>
-          <select name="relative_start_month" class="input-medium" tabindex="4">
-            {{#iterate 1 "Jan, Apr, Jul, Oct" 2 "Feb, May, Aug, Nov" 3 "Mar, Jun, Sep, Dec" step=2 listen=instance.relative_start_month}}
-            <option value="{{iterator_0}}" {{#if_equals instance.relative_start_month iterator_0}}selected="selected"{{/if_equals}}>{{iterator_1}}</option>
+          <select name="relative_start_month" class="input-medium" can-value="instance.relative_start_month" tabindex="4">
+            {{#iterate 1 "Jan, Apr, Jul, Oct" 2 "Feb, May, Aug, Nov" 3 "Mar, Jun, Sep, Dec" step=2}}
+            <option value="{{iterator_0}}">{{iterator_1}}</option>
             {{/iterate}}
           </select>
-          <select name="relative_start_day" class="input-mini" tabindex="5">
-            {{#iterate 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 listen=instance.relative_start_day}}
-            <option {{#if_equals instance.relative_start_day iterator}}selected="selected"{{/if_equals}}>{{iterator}}</option>
+          <select name="relative_start_day" class="input-mini" can-value="instance.relative_start_day" tabindex="5">
+            {{#iterate 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31}}
+            <option value="{{iterator}}">{{iterator}}</option>
             {{/iterate}}
           </select>
         </label>
@@ -178,14 +178,14 @@
             Due
             <span class="required">*</span>
           </span>
-          <select name="relative_end_month" class="input-medium" tabindex="6">
-            {{#iterate 1 "Jan, Apr, Jul, Oct" 2 "Feb, May, Aug, Nov" 3 "Mar, Jun, Sep, Dec" step=2 listen=instance.relative_end_month}}
-            <option value="{{iterator_0}}" {{#if_equals instance.relative_end_month iterator_0}}selected="selected"{{/if_equals}}>{{iterator_1}}</option>
+          <select name="relative_end_month" class="input-medium" can-value="instance.relative_end_month" tabindex="6">
+            {{#iterate 1 "Jan, Apr, Jul, Oct" 2 "Feb, May, Aug, Nov" 3 "Mar, Jun, Sep, Dec" step=2}}
+            <option value="{{iterator_0}}">{{iterator_1}}</option>
             {{/iterate}}
           </select>
-          <select name="relative_end_day" class="input-mini" tabindex="7">
-            {{#iterate 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 listen=instance.relative_end_day}}
-            <option {{#if_equals instance.relative_end_day iterator}}selected="selected"{{/if_equals}}>{{iterator}}</option>
+          <select name="relative_end_day" class="input-mini" can-value="instance.relative_end_day" tabindex="7">
+            {{#iterate 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31}}
+            <option value="{{iterator}}">{{iterator}}</option>
             {{/iterate}}
           </select>
         </label>
@@ -202,14 +202,14 @@
             Starts every
             <span class="required">*</span>
           </span>
-          <select name="relative_start_month" class="input-small" tabindex="4">
-            {{#iterate 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December" step=2 listen=instance.relative_start_month}}
-              <option value="{{iterator_0}}" {{#if_equals iterator_0 instance.relative_start_month}}selected="selected"{{/if_equals}}>{{iterator_1}}</option>
+          <select name="relative_start_month" class="input-small" can-value="instance.relative_start_month" tabindex="4">
+            {{#iterate 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December" step=2}}
+              <option value="{{iterator_0}}">{{iterator_1}}</option>
             {{/iterate}}
           </select>
-          <select name="relative_start_day" class="input-mini" tabindex="5">
-            {{#iterate 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 listen=instance.relative_start_day}}
-            <option {{#if_equals instance.relative_start_day iterator}}selected="selected"{{/if_equals}}>{{iterator}}</option>
+          <select name="relative_start_day" class="input-mini" can-value="instance.instance.relative_start_day" tabindex="5">
+            {{#iterate 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31}}
+            <option value="{{iterator}}">{{iterator}}</option>
             {{/iterate}}
           </select>
         </label>
@@ -218,14 +218,14 @@
             Due every
             <span class="required">*</span>
           </span>
-          <select name="relative_end_month" class="input-small" tabindex="6">
-            {{#iterate 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December" step=2 listen=instance.relative_end_month}}
-              <option value="{{iterator_0}}" {{#if_equals iterator_0 instance.relative_end_month}}selected="selected"{{/if_equals}}>{{iterator_1}}</option>
+          <select name="relative_end_month" class="input-small" can-value="instance.relative_end_month" tabindex="6">
+            {{#iterate 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December" step=2}}
+              <option value="{{iterator_0}}">{{iterator_1}}</option>
             {{/iterate}}
           </select>
-          <select name="relative_end_day" class="input-mini" tabindex="7">
-            {{#iterate 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 listen=instance.relative_end_day}}
-            <option {{#if_equals instance.relative_end_day iterator}}selected="selected"{{/if_equals}}>{{iterator}}</option>
+          <select name="relative_end_day" class="input-mini" can-value="instance.relative_end_day" tabindex="7">
+            {{#iterate 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31}}
+            <option value="{{iterator}}">{{iterator}}</option>
             {{/iterate}}
           </select>
         </label>

--- a/src/ggrc_workflows/assets/mustache/task_groups/info.mustache
+++ b/src/ggrc_workflows/assets/mustache/task_groups/info.mustache
@@ -8,7 +8,7 @@
   <section class="info{{#is_info_pin}} sticky-info-panel{{/is_info_pin}}">
 
     {{#is_info_pin}}
-      <info-pin-buttons class="details-wrap" maximized="maximized" on-change-maximized-state="onChangeMaximizedState" on-close="onClose"></info-pin-buttons>
+      <info-pin-buttons class="details-wrap" maximized="maximized" on-change-maximized-state="@onChangeMaximizedState" on-close="@onClose"></info-pin-buttons>
     {{/is_info_pin}}
 
     <div class="info-pane-utility">

--- a/src/ggrc_workflows/assets/mustache/workflows/info.mustache
+++ b/src/ggrc_workflows/assets/mustache/workflows/info.mustache
@@ -7,7 +7,7 @@
 <section class="info{{#is_info_pin}} sticky-info-panel{{/is_info_pin}}">
 
   {{#is_info_pin}}
-    <info-pin-buttons class="details-wrap" maximized="maximized" on-change-maximized-state="onChangeMaximizedState" on-close="onClose"></info-pin-buttons>
+    <info-pin-buttons class="details-wrap" maximized="maximized" on-change-maximized-state="@onChangeMaximizedState" on-close="@onClose"></info-pin-buttons>
   {{/is_info_pin}}
 
   <div class="info-pane-utility">

--- a/src/ggrc_workflows/assets/mustache/workflows/info.mustache
+++ b/src/ggrc_workflows/assets/mustache/workflows/info.mustache
@@ -157,7 +157,7 @@
     </div>
     <div class="row-fluid">
       <div class="span12">
-        {{{render '/static/mustache/custom_attributes/info.mustache' instance=instance}}}
+        {{>'/static/mustache/custom_attributes/info.mustache'}}
       </div>
     </div>
   </div> <!-- end tier-content -->
@@ -170,7 +170,7 @@
         <em>
           Created at {{date created_at}}
           &nbsp;&nbsp;&nbsp;&nbsp;
-          Modified by {{#using person=modified_by}}{{{render '/static/mustache/people/popover.mustache' person=person}}}{{/using}} on {{date updated_at}}
+          Modified by {{#using person=modified_by}}{{>'/static/mustache/people/popover.mustache'}}{{/using}} on {{date updated_at}}
         </em>
       </small>
     </p>

--- a/src/ggrc_workflows/assets/mustache/workflows/tier2_content.mustache
+++ b/src/ggrc_workflows/assets/mustache/workflows/tier2_content.mustache
@@ -6,8 +6,8 @@
 {{> /static/mustache/base_objects/dropdown_menu_tier2.mustache}}
 
 <div class="tier-content">
-  {{{render '/static/mustache/base_objects/general_info.mustache' instance=instance }}}
-  {{{render '/static/mustache/base_objects/description.mustache' instance=instance}}}
+  {{>'/static/mustache/base_objects/general_info.mustache'}}
+  {{>'/static/mustache/base_objects/description.mustache'}}
 
   <div class="row-fluid wrap-row">
     <div class="span6">
@@ -24,8 +24,8 @@
         {{#each authorizations}}
           {{#using role=instance.role}}
             {{#if_equals role.name 'WorkflowOwner'}}
-              {{#using contact=instance.person}}
-                {{{renderLive '/static/mustache/people/popover.mustache' person=contact}}}
+              {{#using person=instance.person}}
+                {{>'/static/mustache/people/popover.mustache'}}
               {{/using}}
             {{/if_equals}}
           {{/using}}


### PR DESCRIPTION
This is a preview PR that attempts to unify the date formats used on the frontend. Date strings must now be in ISO format and are assumed to be in UTC timezone (just like on the server), and are transparently converted to a different format _only when and where required_ for presentation purposes. Also, the backend now only accepts ISO dates only (workarounds for date CustomAttributeValues have been removed).

The two main sources where string <---> Date conversions happen on the frontend (often incorrectly because of local time zones) are date pickers and serialization of CanJS models, and this PR addresses them. There might still be some other places where this happens, but the initial testing on info panes and edit modals succeeded.

(I will send the same PR to develop branch to run the build there, it might be the case that the CanJS upgrade is actually not required for it)