### PR TITLE
GGRC-1614 Allow editing custom roles on Control info pane

### DIFF
--- a/src/ggrc/assets/assets.yaml
+++ b/src/ggrc/assets/assets.yaml
@@ -152,6 +152,7 @@ dashboard-js-files:
   - components/collapsible-panel/collapsible-panel-header.js
   - components/collapsible-panel/collapsible-panel-body.js
   - components/read-more/read-more.js
+
   - components/assessment/mapped-objects/mapped-controls.js
   - components/assessment/mapped-objects/mapped-controls-popover.js
   - components/assessment/mapped-objects/mapped-related-information.js
@@ -223,6 +224,7 @@ dashboard-js-files:
   - components/unified-mapper/mapper-results-columns-configuration.js
   - components/quick_form/quick_add.js
   - components/quick_form/quick_update.js
+  - components/access_control_list/access_control_list.js
   - components/assessment_templates/assessment_templates.js
   - components/modal_wrappers/assessment_template_form.js
   - components/modal_wrappers/checkboxes_to_list.js
@@ -419,6 +421,7 @@ dashboard-js-template-files:
   - components/unified-mapper/mapper-results-items-header.mustache
   - components/unified-mapper/mapper-results-item-attrs.mustache
   - components/unified-mapper/mapper-results-columns-configuration.mustache
+  - components/access_control_list/access_control_list.mustache
   - components/assessment_templates/assessment_templates.mustache
   - components/dropdown/dropdown.mustache
   - components/dropdown/multiselect_dropdown.mustache

--- a/src/ggrc/assets/javascripts/components/access_control_list/access_control_list.js
+++ b/src/ggrc/assets/javascripts/components/access_control_list/access_control_list.js
@@ -172,6 +172,7 @@
         var vm = this.viewModel;
 
         vm.attr('grantingRoleId', 0);
+        vm.attr('_rolesInfoFixed', false);
         vm._rebuildRolesInfo();
       },
 
@@ -184,6 +185,39 @@
         }
 
         this.viewModel._rebuildRolesInfo();
+      },
+
+      // FIXME: For some reson the rolesInfo object might get corrupted and
+      // needs to be manually checked for consistency and fixed if needed. Not
+      // an elegant approach, but it works.
+      '{viewModel.rolesInfo} change': function () {
+        var vm = this.viewModel;
+        var fixNeeded = false;
+
+        if (vm.attr('_rolesInfoFixed')) {
+          // It seems that once the roleInfo object is fixed, the issue does
+          // not occur anymore, thus fixing the object only once suffices.
+          return;
+        }
+
+        vm.attr('rolesInfo').forEach(function (item) {
+          var roleId = item.role.id;
+
+          if (!item.roleAssignments) {
+            return;
+          }
+
+          item.roleAssignments.forEach(function (entry) {
+            if (entry.ac_role_id !== roleId) {
+              fixNeeded = true;
+            }
+          });
+        });
+
+        if (fixNeeded) {
+          vm.attr('_rolesInfoFixed', true);
+          vm._rebuildRolesInfo();
+        }
       }
     }
   });

--- a/src/ggrc/assets/javascripts/components/access_control_list/access_control_list.js
+++ b/src/ggrc/assets/javascripts/components/access_control_list/access_control_list.js
@@ -173,6 +173,17 @@
 
         vm.attr('grantingRoleId', 0);
         vm._rebuildRolesInfo();
+      },
+
+      '{viewModel.instance.access_control_list} change':
+      function (context, ev, index, how, newVal, oldVal) {
+        if (how === 'set') {
+          // we are not interested in collection items' changes, all we care
+          // about is ading and removing role assignments
+          return;
+        }
+
+        this.viewModel._rebuildRolesInfo();
       }
     }
   });

--- a/src/ggrc/assets/javascripts/components/access_control_list/access_control_list.js
+++ b/src/ggrc/assets/javascripts/components/access_control_list/access_control_list.js
@@ -1,0 +1,179 @@
+/*!
+ Copyright (C) 2017 Google Inc.
+ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+ */
+
+(function (can, _, GGRC) {
+  'use strict';
+
+  /**
+   * A component that renders a list of access permissions granted on the given
+   * instance of a roleable model.
+   *
+   * Permissions are goruped by their access control role type and can be
+   * edited by users.
+   */
+  GGRC.Components('accessControlList', {
+    tag: 'access-control-list',
+    template: can.view(
+      GGRC.mustache_path +
+      '/components/access_control_list/access_control_list.mustache'
+    ),
+
+    viewModel: {
+      instance: null,
+
+      define: {
+        // whether or not to automatically save instance on person role changes
+        autosave: {
+          type: 'boolean',
+          value: false
+        },
+        // the extra CSS class(es) to apply to each role list block
+        roleBlockClass: {
+          type: 'string',
+          value: 'row-fluid'
+        }
+      },
+
+      /**
+       * Enter the "grant role" mode for a particular role.
+       *
+       * It effectively displays the UI widget for granting a person that role.
+       *
+       * @param {Number} roleId - the role ID for which to enable the "grant
+       *   role" mode
+       */
+      grantRoleMode: function (roleId) {
+        this.attr('grantingRoleId', roleId);
+      },
+
+      /**
+       * Grant role to user on the model instance.
+       *
+       * If the user already has this role assigned on the model instance,
+       * nothing happens.
+       *
+       * @param {CMS.Models.Person} person - the user to grant a role to
+       * @param {Number} roleId - ID if the role to grant
+       */
+      grantRole: function (person, roleId) {
+        var inst = this.instance;
+
+        var roleEntry = _.find(
+          inst.attr('access_control_list'),
+          {person_id: person.id, ac_role_id: roleId}
+        );
+
+        if (roleEntry) {
+          console.warn(
+            'User ', person.id, 'already has role', roleId, 'assigned');
+          return;
+        }
+
+        roleEntry = {person: person, ac_role_id: roleId};
+        inst.attr('access_control_list').push(roleEntry);
+
+        if (!this.autosave) {
+          this.attr('grantingRoleId', 0);
+          this._rebuildRolesInfo();
+          return;
+        }
+
+        inst.save()
+          .done(function () {
+            GGRC.Errors.notifier('success', 'User role added.');
+            this._rebuildRolesInfo();
+          }.bind(this))
+          .fail(function () {
+            GGRC.Errors.notifier('error', 'Adding user role failed.');
+          })
+          .always(function () {
+            this.attr('grantingRoleId', 0);
+          }.bind(this));
+      },
+
+      /**
+       * Revoke role from user on the model instance.
+       *
+       * If the user already does not have this role assigned on the model
+       * instance, nothing happens.
+       *
+       * @param {CMS.Models.Person} person - the user to grant a role to
+       * @param {Number} roleId - ID if the role to grant
+       */
+      revokeRole: function (person, roleId) {
+        var inst = this.instance;
+
+        var idx = _.findIndex(
+          inst.attr('access_control_list'),
+          {person_id: person.id, ac_role_id: roleId}
+        );
+
+        if (idx < 0) {
+          console.warn('Role ', roleId, 'not found for user', person.id);
+          return;
+        }
+
+        inst.access_control_list.splice(idx, 1);
+
+        if (!this.autosave) {
+          this._rebuildRolesInfo();
+          return;
+        }
+
+        inst.save()
+          .done(function () {
+            GGRC.Errors.notifier('success', 'User role removed.');
+            this._rebuildRolesInfo();
+          }.bind(this))
+          .fail(function () {
+            GGRC.Errors.notifier('error', 'Removing user role failed.');
+          });
+      },
+
+      /**
+       * Update the role info object used by the template to display the roles
+       * and the users which have them granted.
+       */
+      _rebuildRolesInfo: function () {
+        var roleAssignments;
+        var roles;
+        var rolesInfo;
+        var instance = this.instance;
+
+        if (!instance) {
+          this.attr('rolesInfo', []);
+          return;
+        }
+
+        roleAssignments = _.groupBy(instance.access_control_list, 'ac_role_id');
+
+        roles = _.filter(
+          GGRC.access_control_roles, {object_type: instance.type});
+
+        rolesInfo = _.map(roles, function (role) {
+          return {role: role, roleAssignments: roleAssignments[role.id]};
+        });
+
+        this.attr('rolesInfo', rolesInfo);
+      }
+    },
+
+    events: {
+      /**
+       * The component entry point.
+       *
+       * @param {jQuery} $element - the DOM element that triggered
+       *   creating the component instance
+       * @param {Object} options - the component instantiation options
+       */
+      init: function ($element, options) {
+        var vm = this.viewModel;
+
+        vm.attr('grantingRoleId', 0);
+        vm._rebuildRolesInfo();
+      }
+    }
+  });
+})(window.can, window._, window.GGRC);

--- a/src/ggrc/assets/javascripts/components/autocomplete/autocomplete.js
+++ b/src/ggrc/assets/javascripts/components/autocomplete/autocomplete.js
@@ -57,6 +57,14 @@
           type: component._EV_ITEM_SELECTED,
           selectedItem: data.item
         });
+
+        // keep the legacy event emitting mechanism above, but emit the event
+        // using the more modern dispatch mechanism, too
+        this.viewModel.dispatch({
+          type: 'itemSelected',
+          selectedItem: data.item
+        });
+
         // If the input still has focus after selecting an item, search results
         // do not appear unless user clicks out and back in the input (or
         // starts typing). Removing the focus spares one unnecessary click.

--- a/src/ggrc/assets/javascripts/components/autocomplete/tests/autocomplete_spec.js
+++ b/src/ggrc/assets/javascripts/components/autocomplete/tests/autocomplete_spec.js
@@ -27,15 +27,17 @@ describe('GGRC.Components.autocomplete', function () {
   describe('item selected event handler', function () {
     var eventData;
     var eventObj;
+    var fakeViewModel;
     var handler;  // the event handler under test
     var $childInput;
     var $element;
 
-    beforeAll(function () {
-      handler = Component.prototype.events['autocomplete:select'];
-    });
-
     beforeEach(function () {
+      fakeViewModel = new can.Map({});
+      handler = Component.prototype.events['autocomplete:select'].bind({
+        viewModel: fakeViewModel
+      });
+
       eventData = {
         item: {id: 123, type: 'Foo'}
       };
@@ -62,6 +64,19 @@ describe('GGRC.Components.autocomplete', function () {
 
         expect($element.triggerHandler).toHaveBeenCalledWith({
           type: Component.prototype._EV_ITEM_SELECTED,
+          selectedItem: {id: 123, type: 'Foo'}
+        });
+      }
+    );
+
+    it('emits the item-selected event using the dispatch mechanism',
+      function () {
+        spyOn(fakeViewModel, 'dispatch');
+
+        handler($element, eventObj, eventData);
+
+        expect(fakeViewModel.dispatch).toHaveBeenCalledWith({
+          type: 'itemSelected',
           selectedItem: {id: 123, type: 'Foo'}
         });
       }

--- a/src/ggrc/assets/javascripts/components/person/person.js
+++ b/src/ggrc/assets/javascripts/components/person/person.js
@@ -102,6 +102,13 @@
           type: component._EV_REMOVE_CLICK,
           person: this.scope.personObj
         });
+
+        // keep the legacy event emitting mechanism above, but emit the event
+        // using the more modern dispatch mechanism, too
+        this.viewModel.dispatch({
+          type: 'personRemove',
+          person: this.scope.personObj
+        });
       }
     }
   };

--- a/src/ggrc/assets/javascripts/components/person/tests/person_spec.js
+++ b/src/ggrc/assets/javascripts/components/person/tests/person_spec.js
@@ -176,10 +176,6 @@ describe('GGRC.Components.personItem', function () {
     var handler;  // the event handler under test
     var componentInst;  // fake component instance
 
-    beforeAll(function () {
-      handler = Component.prototype.events['a.unmap click'];
-    });
-
     beforeEach(function () {
       componentInst = {
         element: {
@@ -187,8 +183,9 @@ describe('GGRC.Components.personItem', function () {
         },
         scope: new can.Map()
       };
+      componentInst.viewModel = componentInst.scope;
 
-      handler = handler.bind(componentInst);
+      handler = Component.prototype.events['a.unmap click'].bind(componentInst);
     });
 
     it('triggers the person-remove event with the person object as the ' +
@@ -203,6 +200,21 @@ describe('GGRC.Components.personItem', function () {
         call = componentInst.element.triggerHandler.calls.mostRecent();
         expect(call.args[0].type).toEqual(
           Component.prototype._EV_REMOVE_CLICK);
+        expect(call.args[0].person.attr()).toEqual({id: 123, name: 'John'});
+      }
+    );
+
+    it('emits the person-remove event using the dispatch mechanism',
+      function () {
+        var call;
+        componentInst.viewModel.attr('personObj', {id: 123, name: 'John'});
+        spyOn(componentInst.viewModel, 'dispatch');
+
+        handler();
+
+        expect(componentInst.viewModel.dispatch).toHaveBeenCalled();
+        call = componentInst.viewModel.dispatch.calls.mostRecent();
+        expect(call.args[0].type).toEqual('personRemove');
         expect(call.args[0].person.attr()).toEqual({id: 123, name: 'John'});
       }
     );

--- a/src/ggrc/assets/javascripts/models/custom_roles.js
+++ b/src/ggrc/assets/javascripts/models/custom_roles.js
@@ -61,6 +61,11 @@
     destroy: 'DELETE /api/access_control_roles/{id}',
     mixins: [],
     attributes: {},
+    defaults: {
+      read: true,
+      update: true,
+      delete: true
+    },
     links_to: {},
     init: function () {
       this.validateNonBlank('name');

--- a/src/ggrc/assets/mustache/components/access_control_list/access_control_list.mustache
+++ b/src/ggrc/assets/mustache/components/access_control_list/access_control_list.mustache
@@ -6,10 +6,10 @@
 <div class="span6">
 
   {{#rolesInfo}}
-    <div class="{{roleBlockClass}}">
+    <div class="{{roleBlockClass}} bottom-spacing role-block">
       <h6>
         {{role.name}}
-        <i class="fa fa-plus-circle"
+        <i class="fa fa-plus-circle add-role"
            title="Grant Role {{role.name}}"
            ($click)="grantRoleMode(role.id)"></i>
       </h6>
@@ -23,7 +23,9 @@
       {{/if}}
 
       {{^roleAssignments}}
-        <span class="empty-message">None</span>
+        <p>
+          <span class="empty-message">None</span>
+        </p>
       {{/roleAssignments}}
 
       {{#roleAssignments}}

--- a/src/ggrc/assets/mustache/components/access_control_list/access_control_list.mustache
+++ b/src/ggrc/assets/mustache/components/access_control_list/access_control_list.mustache
@@ -1,0 +1,39 @@
+{{!
+  Copyright (C) 2017 Google Inc.
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+}}
+
+<div class="span6">
+
+  {{#rolesInfo}}
+    <div class="{{roleBlockClass}}">
+      <h6>
+        {{role.name}}
+        <i class="fa fa-plus-circle"
+           title="Grant Role {{role.name}}"
+           ($click)="grantRoleMode(role.id)"></i>
+      </h6>
+
+      {{#if_equals role.id grantingRoleId}}
+        <autocomplete
+          search-items-type="Person"
+          (item-selected)="grantRole(%event.selectedItem, %context.role.id)"
+          placeholder="Select person"
+        ></autocomplete>
+      {{/if}}
+
+      {{^roleAssignments}}
+        <span class="empty-message">None</span>
+      {{/roleAssignments}}
+
+      {{#roleAssignments}}
+        <person-info
+          person-id="person.id"
+          editable="true"
+          (person-remove)="revokeRole(%event.person, %context.ac_role_id)"
+          ></person-info>
+      {{/roleAssignments}}
+    </div>
+  {{/rolesInfo}}
+
+</div>

--- a/src/ggrc/assets/mustache/controls/contacts.mustache
+++ b/src/ggrc/assets/mustache/controls/contacts.mustache
@@ -5,7 +5,7 @@
 
 {{#instance}}
 <div class="row-fluid wrap-row">
-  <div data-test-id="title_manager_7a906d2e" class="span4">
+  <div data-test-id="title_manager_7a906d2e" class="span6">
     {{#if is_program}}
     <h6>Manager</h6>
     <p class="oneline">
@@ -47,7 +47,7 @@
     {{/if}}
     </p>
   </div>
-  <div class="span4">
+  <div class="span6">
     {{#using person=contact}}
       <div class="bottom-space">
         <h6>Primary Contact</h6>
@@ -98,7 +98,12 @@
       </div>
     {{/using}}
   </div>
-  <div class="span4">
+</div>
+
+<div class="row-fluid wrap-row">
+  <access-control-list instance="." autosave="true"></access-control-list>
+
+  <div class="span6">
     {{>'/static/mustache/controls/urls.mustache'}}
   </div>
 </div>

--- a/src/ggrc/assets/mustache/controls/info.mustache
+++ b/src/ggrc/assets/mustache/controls/info.mustache
@@ -19,8 +19,6 @@
       {{>'/static/mustache/base_objects/notes.mustache'}}
       {{>'/static/mustache/controls/contacts.mustache'}}
 
-      <access-control-list instance="." autosave="true"></access-control-list>
-
       <div class="custom-attr-wrap">
         <div class="row-fluid">
           <div class="span12">

--- a/src/ggrc/assets/mustache/controls/info.mustache
+++ b/src/ggrc/assets/mustache/controls/info.mustache
@@ -19,6 +19,8 @@
       {{>'/static/mustache/base_objects/notes.mustache'}}
       {{>'/static/mustache/controls/contacts.mustache'}}
 
+      <access-control-list instance="." autosave="true"></access-control-list>
+
       <div class="custom-attr-wrap">
         <div class="row-fluid">
           <div class="span12">

--- a/src/ggrc/assets/mustache/controls/modal_content.mustache
+++ b/src/ggrc/assets/mustache/controls/modal_content.mustache
@@ -55,9 +55,14 @@
       </div>
     </div>
 
-
     <div data-test-id="control_contacts_8bd3d8c7" class="span6 hide-wrap hidable">
       {{> /static/mustache/base_objects/modal_contact_fields.mustache}}
+    </div>
+  </div>
+
+  <div class="row-fluid">
+    <div class="span12 hide-wrap hidable">
+      <access-control-list instance="."></access-control-list>
     </div>
   </div>
 

--- a/src/ggrc/assets/mustache/controls/modal_content.mustache
+++ b/src/ggrc/assets/mustache/controls/modal_content.mustache
@@ -60,9 +60,11 @@
     </div>
   </div>
 
-  <div class="row-fluid">
-    <div class="span12 hide-wrap hidable">
-      <access-control-list instance="."></access-control-list>
+  <div class="row">
+    <div class="span6 offset6 hide-wrap hidable">
+      <access-control-list
+          instance="."
+          role-block-class="'row'"></access-control-list>
     </div>
   </div>
 

--- a/src/ggrc/assets/stylesheets/_components.scss
+++ b/src/ggrc/assets/stylesheets/_components.scss
@@ -3,6 +3,7 @@
  * Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
  */
 
+@import "components/access-control-list/access-control-list";
 @import "components/comment/comment-input";
 @import "components/comment/comment-control";
 @import "components/tree_pagination/tree_pagination";

--- a/src/ggrc/assets/stylesheets/components/access-control-list/_access-control-list.scss
+++ b/src/ggrc/assets/stylesheets/components/access-control-list/_access-control-list.scss
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2017 Google Inc.
+ * Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+ */
+
+access-control-list {
+  .role-block {
+    .add-role {
+      cursor: pointer;
+      margin-left: 0.3em;
+      color: $defaultGreen;
+    }
+    .autocomplete--wrapper {
+      .modal-body & {
+        max-width: 92%;
+      }
+    }
+    .person {
+      margin-bottom: 0.3em;
+      a.unmap {
+        cursor: pointer;
+      }
+    }
+  }
+}


### PR DESCRIPTION
This is a preview PR and might not be ready to be merged yet - still need to improve UX a bit, add tests and enable editing roles in the create/edit modal.

The PR, however,  is already quite functional, it allows assigning/revoking roles, and the general structure of the `accessControlList` component will likely not be changing (much) anymore.